### PR TITLE
Use second argument to string.split() to speed up getRole.

### DIFF
--- a/src/extends/creep.js
+++ b/src/extends/creep.js
@@ -7,7 +7,7 @@ Creep.getRole = function (roleName) {
 
 Creep.prototype.getRole = function () {
   // If the creep role isn't in memory grab it based off of the name
-  var roleType = this.memory.role ? this.memory.role : this.name.split('_')[0]
+  var roleType = this.memory.role ? this.memory.role : this.name.split('_', 1)[0]
   return Creep.getRole(roleType)
 }
 


### PR DESCRIPTION
`.split('_', 1)` will build an array with at least 1 fewer elements, providing an exponential speed increase to all screeps operations!

What better for a first contribution than premature optimization?