### PR TITLE
Bugfix: Don't log errors for successful createCreep calls

### DIFF
--- a/src/programs/spawns.js
+++ b/src/programs/spawns.js
@@ -16,7 +16,7 @@ class Spawns extends kernel.process {
         break
       }
       var ret = spawn.createCreep(creep.build, creep.name, creep.memory)
-      if (ret !== OK) {
+      if (Number.isInteger(ret)) {
         Logger.log('Error ' + ret + ' while spawning creep ' + creep.name, LOG_ERROR)
       }
     }

--- a/src/programs/spawns.js
+++ b/src/programs/spawns.js
@@ -17,7 +17,9 @@ class Spawns extends kernel.process {
       }
       var ret = spawn.createCreep(creep.build, creep.name, creep.memory)
       if (Number.isInteger(ret)) {
-        Logger.log('Error ' + ret + ' while spawning creep ' + creep.name, LOG_ERROR)
+        Logger.log('Error ' + ret + ' while spawning creep ' + creep.name + ' in room ' + this.data.room, LOG_ERROR)
+      } else {
+        Logger.log('Spawning creep ' + creep.name + ' from ' + this.data.room)
       }
     }
   }


### PR DESCRIPTION
This bug exists because I forgot that createCreep returns the creep name and not the `OK` return code most functions use.