### PR TITLE
Add "Autobuild", builder and filler roles, and room reboot

### DIFF
--- a/src/extends/room/logistics.js
+++ b/src/extends/room/logistics.js
@@ -1,0 +1,20 @@
+'use strict'
+
+const FILLABLE_STRUCTURES = [
+  STRUCTURE_SPAWN,
+  STRUCTURE_EXTENSION,
+  STRUCTURE_TOWER
+]
+
+Room.prototype.getStructuresToFill = function () {
+  if (!this.__fillable) {
+    this.__fillable = this.find(FIND_MY_STRUCTURES, {filter: function (structure) {
+      if (FILLABLE_STRUCTURES.indexOf(structure.structureType) === -1) {
+        return false
+      }
+
+      return structure.energy < structure.energyCapacity
+    }})
+  }
+  return this.__fillable
+}

--- a/src/extends/room/spawning.js
+++ b/src/extends/room/spawning.js
@@ -1,7 +1,14 @@
 'use strict'
 
+const SPAWN_DEFAULT_PRIORITY = 4
+
 Room.prototype.queueCreep = function (role, options = {}) {
   var name = role + '_' + sos.lib.counter.get(role).toString(36)
+
+  if (!options.priority) {
+    options.priority = 3
+  }
+
   if (!Memory.spawnqueue) {
     Memory.spawnqueue = {}
   }
@@ -11,7 +18,7 @@ Room.prototype.queueCreep = function (role, options = {}) {
   if (!Memory.spawnqueue.index[this.name]) {
     Memory.spawnqueue.index[this.name] = {}
   }
-  if (!options.energy) {
+  if (!options.energy || options.energy > this.energyCapacityAvailable) {
     options.energy = this.energyCapacityAvailable
   }
   options.role = role
@@ -36,8 +43,8 @@ Room.prototype.getQueuedCreep = function () {
   }
   var that = this
   creeps.sort(function (a, b) {
-    var aP = Memory.spawnqueue.index[that.name][a].priority ? Memory.spawnqueue.index[that.name][a].priority : 3
-    var bP = Memory.spawnqueue.index[that.name][b].priority ? Memory.spawnqueue.index[that.name][b].priority : 3
+    var aP = Memory.spawnqueue.index[that.name][a].priority ? Memory.spawnqueue.index[that.name][a].priority : SPAWN_DEFAULT_PRIORITY
+    var bP = Memory.spawnqueue.index[that.name][b].priority ? Memory.spawnqueue.index[that.name][b].priority : SPAWN_DEFAULT_PRIORITY
     return aP - bP
   })
 

--- a/src/extends/roomposition.js
+++ b/src/extends/roomposition.js
@@ -63,3 +63,7 @@ RoomPosition.prototype.inFrontOfExit = function () {
 RoomPosition.prototype.getTerrainAt = function () {
   return Game.map.getTerrainAt(this)
 }
+
+RoomPosition.prototype.getManhattanDistance = function (pos) {
+  return Math.abs(this.x - pos.x) + Math.abs(this.y - pos.y)
+}

--- a/src/main.js
+++ b/src/main.js
@@ -27,8 +27,9 @@ require('thirdparty_creeptalk')({'public': true, 'language': language})
 
 /* Extend built in objects */
 require('extends_creep')
-require('extends_room')
 require('extends_room_construction')
+require('extends_room_logistics')
+require('extends_room_spawning')
 require('extends_roomposition')
 
 var QosKernel = require('qos_kernel')

--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -8,14 +8,20 @@ class City extends kernel.process {
 
     this.launchChildProcess('spawns', 'spawns', {'room': this.data.room})
     this.launchChildProcess('defense', 'city_defense', {'room': this.data.room})
+    this.launchChildProcess('reboot', 'city_reboot', {'room': this.data.room})
 
-    // If the room isn't planned launch the room layout program
+    // If the room isn't planned launch the room layout program, otherwise launch construction program
     if (!this.room.getLayout().isPlanned()) {
       this.launchChildProcess('layout', 'city_layout', {'room': this.data.room})
+    } else {
+      this.launchChildProcess('construct', 'city_construct', {'room': this.data.room})
     }
 
+    // Launch fillers
+    this.launchCreepProcess('fillers', 'filler', this.data.room, 2)
+
     // Launch upgraders
-    this.launchCreepProcess('upgraders', 'upgrader', this.data.room, 5)
+    this.launchCreepProcess('upgraders', 'upgrader', this.data.room, 5, {'priority': 5})
   }
 }
 

--- a/src/programs/city/construct.js
+++ b/src/programs/city/construct.js
@@ -1,0 +1,29 @@
+/**
+ *
+ */
+
+class CityConstruct extends kernel.process {
+  main () {
+    if (!Game.rooms[this.data.room]) {
+      return this.suicide()
+    }
+    this.room = Game.rooms[this.data.room]
+
+    if (!this.room.isMissingStructures()) {
+      return
+    }
+
+    var sites = this.room.find(FIND_MY_CONSTRUCTION_SITES, {filter: function (site) {
+      return site.structureType != STRUCTURE_ROAD && site.structureType != STRUCTURE_CONTAINER
+    }})
+    if (sites.length <= 0) {
+      this.room.constructNextMissingStructure()
+    }
+
+    if (sites.length > 0) {
+      this.launchCreepProcess('builders', 'builder', this.data.room, 2)
+    }
+  }
+}
+
+module.exports = CityConstruct

--- a/src/programs/city/reboot.js
+++ b/src/programs/city/reboot.js
@@ -1,0 +1,17 @@
+/**
+ * Provide Room-level Security
+ */
+
+class CityReboot extends kernel.process {
+  main () {
+    if (!Game.rooms[this.data.room]) {
+      return this.suicide()
+    }
+    this.room = Game.rooms[this.data.room]
+    if(this.room.find(FIND_MY_CREEPS).length <= 0) {
+      this.launchCreepProcess('rebooter', 'filler', this.data.room, 2, {priority: 1, energy: 300})
+    }
+  }
+}
+
+module.exports = CityReboot

--- a/src/programs/city/reboot.js
+++ b/src/programs/city/reboot.js
@@ -1,5 +1,5 @@
 /**
- * Provide Room-level Security
+ * Attempts to prevent stalled rooms by launching filler creeps at 300 energy.
  */
 
 class CityReboot extends kernel.process {

--- a/src/roles/builder.js
+++ b/src/roles/builder.js
@@ -1,0 +1,36 @@
+const MetaRole = require('roles_meta')
+
+class Builder extends MetaRole {
+  getBuild (options) {
+    return Creep.buildFromTemplate([MOVE, CARRY, WORK], options.energy)
+  }
+
+  manageCreep (creep) {
+    if (this.recharge(creep)) {
+      return
+    }
+
+    // Find and build any construction sites
+    var construction = creep.pos.findClosestByRange(FIND_MY_CONSTRUCTION_SITES)
+    if (construction) {
+      if (creep.pos.getRangeTo(construction) > 2) {
+        creep.moveTo(construction)
+      }
+      if (creep.pos.getRangeTo(construction) <= 3) {
+        creep.build(construction)
+      }
+      return
+    }
+
+    // Upgrade controller if there isn't anything to build
+    var controller = creep.room.controller
+    if (creep.pos.getRangeTo(controller) > 2) {
+      creep.moveTo(controller)
+    }
+    if (creep.pos.getRangeTo(controller) <= 3) {
+      creep.upgradeController(controller)
+    }
+  }
+}
+
+module.exports = Builder

--- a/src/roles/filler.js
+++ b/src/roles/filler.js
@@ -1,0 +1,39 @@
+const MetaRole = require('roles_meta')
+
+class Builder extends MetaRole {
+  getBuild (options) {
+    return Creep.buildFromTemplate([MOVE, CARRY, WORK], options.energy)
+  }
+
+  manageCreep (creep) {
+    if (this.recharge(creep)) {
+      return
+    }
+
+    // Find structure to fill
+    var structure = creep.pos.findClosestByRange(creep.room.getStructuresToFill())
+    if (structure) {
+      if (creep.pos.getRangeTo(structure) > 1) {
+        creep.moveTo(structure)
+      }
+      if (creep.pos.getRangeTo(structure) <= 1) {
+        creep.transfer(structure, RESOURCE_ENERGY)
+      }
+      return
+    }
+
+    // Park
+    if (creep.room.storage) {
+      var target = creep.room.storage
+    } else {
+      var spawns = creep.room.find(FIND_MY_SPAWNS)
+      var target = spawns[0]
+    }
+    if (creep.pos.getRangeTo(target) > 3) {
+      creep.moveTo(target)
+    }
+
+  }
+}
+
+module.exports = Builder

--- a/src/roles/filler.js
+++ b/src/roles/filler.js
@@ -1,6 +1,6 @@
 const MetaRole = require('roles_meta')
 
-class Builder extends MetaRole {
+class Filler extends MetaRole {
   getBuild (options) {
     return Creep.buildFromTemplate([MOVE, CARRY, WORK], options.energy)
   }
@@ -36,4 +36,4 @@ class Builder extends MetaRole {
   }
 }
 
-module.exports = Builder
+module.exports = Filler

--- a/src/roles/meta.js
+++ b/src/roles/meta.js
@@ -1,0 +1,27 @@
+
+class MetaRole {
+
+  recharge(creep) {
+    if (creep.carry[RESOURCE_ENERGY] <= 0) {
+      creep.memory.recharge = true
+    }
+    if (creep.carry[RESOURCE_ENERGY] >= creep.carryCapacity) {
+      creep.memory.recharge = false
+    }
+    if (creep.memory.recharge) {
+      var sources = creep.room.find(FIND_SOURCES_ACTIVE)
+      var source = creep.pos.findClosestByRange(sources)
+      if (!creep.pos.isNearTo(source)) {
+        creep.moveTo(source)
+      }
+      if (creep.pos.isNearTo(source)) {
+        creep.harvest(source)
+      }
+      return true
+    }
+    return false
+  }
+
+}
+
+module.exports = MetaRole

--- a/src/roles/upgrader.js
+++ b/src/roles/upgrader.js
@@ -1,27 +1,14 @@
+const MetaRole = require('roles_meta')
 
 const CONTROLLER_MESSAGE = "* Self Managed Code * quorum.tedivm.com * #quorum in Slack *"
 
-class Upgrader {
+class Upgrader extends MetaRole {
   getBuild (options) {
     return Creep.buildFromTemplate([MOVE, CARRY, WORK], options.energy)
   }
 
   manageCreep (creep) {
-    if (creep.carry[RESOURCE_ENERGY] <= 0) {
-      creep.memory.recharge = true
-    }
-    if (creep.carry[RESOURCE_ENERGY] >= creep.carryCapacity) {
-      creep.memory.recharge = false
-    }
-    if (creep.memory.recharge) {
-      var sources = creep.room.find(FIND_SOURCES_ACTIVE)
-      var source = creep.pos.findClosestByRange(sources)
-      if (!creep.pos.isNearTo(source)) {
-        creep.moveTo(source)
-      }
-      if (creep.pos.isNearTo(source)) {
-        creep.harvest(source)
-      }
+    if (this.recharge(creep)) {
       return
     }
 


### PR DESCRIPTION
* Creates the concept of `practicalRoomLevel`, which can be compared against the real room level to see what structures should be built next. This means that a room being built up multiple levels won't just build up a specific building type, but will go from one room level to another until everything is complete. 

* The closest planned structures to the storage location are built first.

* Roads, Links, Walls, and Ramparts are not included in this.

* The `Builder` role is used to actually complete the structures. It will upgrade the controller if there isn't anything to build.

* A basic `Filler` role refills the spawns and extensions. Without this the rooms would die as they attempt to build creeps they can't actually support.

* A very basic "reboot" program has been added to spawn a 300 energy filler whenever the room is dead.