### PR TITLE
More detailed logging about what processes are running

### DIFF
--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -1,5 +1,9 @@
 
 class City extends kernel.process {
+  getDescriptor () {
+    return this.data.room
+  }
+
   main () {
     if (!Game.rooms[this.data.room]) {
       return this.suicide()

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -3,6 +3,10 @@
  */
 
 class CityDefense extends kernel.process {
+  getDescriptor () {
+    return this.data.room
+  }
+
   main () {
     if (!Game.rooms[this.data.room]) {
       return this.suicide()

--- a/src/programs/city/layout.js
+++ b/src/programs/city/layout.js
@@ -34,6 +34,10 @@ var LAYOUT_FLOWER = [
 
 
 class CityLayout extends kernel.process {
+  getDescriptor () {
+    return this.data.room
+  }
+
   main () {
     if (!Game.rooms[this.data.room]) {
       return this.suicide()

--- a/src/programs/creep.js
+++ b/src/programs/creep.js
@@ -3,6 +3,10 @@
  */
 
 class ProgramCreep extends kernel.process {
+  getDescriptor () {
+    return this.data.creep
+  }
+
   main () {
     // See if creep is dead and if so close this process
     if (!Game.creeps[this.data.creep]) {

--- a/src/programs/spawns.js
+++ b/src/programs/spawns.js
@@ -1,5 +1,9 @@
 
 class Spawns extends kernel.process {
+  getDescriptor () {
+    return this.data.room
+  }
+
   main () {
     if (!Game.rooms[this.data.room]) {
       return this.suicide()

--- a/src/qos/kernel.js
+++ b/src/qos/kernel.js
@@ -61,7 +61,14 @@ class QosKernel {
       }
       Logger.defaultLogGroup = runningProcess.name
       try {
-        Logger.log('Running ' + runningProcess.name + ' (pid ' + runningProcess.pid + ')', LOG_INFO, 'kernel')
+
+        var processName = runningProcess.name
+        var descriptor = runningProcess.getDescriptor()
+        if(descriptor) {
+          processName += ' ' + descriptor
+        }
+
+        Logger.log('Running ' + processName + ' (pid ' + runningProcess.pid + ')', LOG_INFO, 'kernel')
         runningProcess.run()
       } catch (err) {
         Logger.log('program error occurred', LOG_ERROR)

--- a/src/qos/process.js
+++ b/src/qos/process.js
@@ -25,6 +25,10 @@ class Process {
     }
   }
 
+  getDescriptor () {
+    return false
+  }
+
   launchChildProcess (label, name, data = {}) {
     if (!this.data.children) {
       this.data.children = {}


### PR DESCRIPTION
This adds a new function (`getDescriptor`) to the `Process` class. Programs can override this function to return a string which will be added to the process name in console logs.

For example, this can (and is) used to add the room name to all room processes, and the creep name to all running creep processes.