### PR TITLE
Balance across available sources

### DIFF
--- a/src/roles/meta.js
+++ b/src/roles/meta.js
@@ -10,7 +10,8 @@ class MetaRole {
     }
     if (creep.memory.recharge) {
       var sources = creep.room.find(FIND_SOURCES_ACTIVE)
-      var source = creep.pos.findClosestByRange(sources)
+      let idx = parseInt(creep.name[creep.name.length - 1], 36)
+      var source = sources[idx % sources.length]
       if (!creep.pos.isNearTo(source)) {
         creep.moveTo(source)
       }


### PR DESCRIPTION
The current algorithm for source selection tends to get all creeps "stuck" on
a single source. If that source only has one access tile, things get ugly fast.

This changes source selection so it depends on the creep ID, balanced across
all active sources in the room.