### PR TITLE
Use `SPAWN_DEFAULT_PRIORITY`

### DIFF
--- a/src/extends/room/spawning.js
+++ b/src/extends/room/spawning.js
@@ -6,7 +6,7 @@ Room.prototype.queueCreep = function (role, options = {}) {
   var name = role + '_' + sos.lib.counter.get(role).toString(36)
 
   if (!options.priority) {
-    options.priority = 3
+    options.priority = SPAWN_DEFAULT_PRIORITY
   }
 
   if (!Memory.spawnqueue) {


### PR DESCRIPTION
There was one spot where the hardcoded value was still being used.