### PR TITLE
Split tower filling duties to a dedicated role

### DIFF
--- a/src/extends/room/logistics.js
+++ b/src/extends/room/logistics.js
@@ -1,15 +1,9 @@
 'use strict'
 
-const FILLABLE_STRUCTURES = [
-  STRUCTURE_SPAWN,
-  STRUCTURE_EXTENSION,
-  STRUCTURE_TOWER
-]
-
-Room.prototype.getStructuresToFill = function () {
+Room.prototype.getStructuresToFill = function (structureTypes) {
   if (!this.__fillable) {
     this.__fillable = this.find(FIND_MY_STRUCTURES, {filter: function (structure) {
-      if (FILLABLE_STRUCTURES.indexOf(structure.structureType) === -1) {
+      if (structureTypes.indexOf(structure.structureType) === -1) {
         return false
       }
 

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -25,6 +25,10 @@ class CityDefense extends kernel.process {
       this.fireTowers(towers, hostiles)
     }
 
+    if (towers && _.some(towers, (tower) => tower.energy < tower.energyCapacity)) {
+      this.launchCreepProcess('loader', 'replenisher', this.data.room, 1)
+    }
+
     const playerHostiles = hostiles.filter(c => c.owner.username !== 'Invader')
     if (playerHostiles.length > 0) {
       Logger.log(`Hostile creep owned by ${c.owner.username} detected in room ${this.data.room}.`, LOG_WARN)

--- a/src/roles/filler.js
+++ b/src/roles/filler.js
@@ -1,6 +1,12 @@
 const MetaRole = require('roles_meta')
 
 class Filler extends MetaRole {
+
+  constructor () {
+    super()
+    this.fillableStructures = [STRUCTURE_SPAWN, STRUCTURE_EXTENSION]
+  }
+
   getBuild (options) {
     return Creep.buildFromTemplate([MOVE, CARRY, WORK], options.energy)
   }
@@ -11,7 +17,8 @@ class Filler extends MetaRole {
     }
 
     // Find structure to fill
-    var structure = creep.pos.findClosestByRange(creep.room.getStructuresToFill())
+    var structure = creep.pos.findClosestByRange(creep.room.getStructuresToFill(this.fillableStructures))
+
     if (structure) {
       if (creep.pos.getRangeTo(structure) > 1) {
         creep.moveTo(structure)

--- a/src/roles/replenisher.js
+++ b/src/roles/replenisher.js
@@ -1,0 +1,10 @@
+const Filler = require('roles_filler')
+
+class Replenisher extends Filler {
+  constructor () {
+    super()
+    this.fillableStructures = [STRUCTURE_TOWER]
+  }
+}
+
+module.exports = Replenisher


### PR DESCRIPTION
This adds an argument to `Room.prototype.getStructuresToFill` for structure types. It then adds a constructor based property to the `Filler` role, making it easier to split off new roles that only fill specific structures.