### PR TITLE
Sort sources by distance to controller

### DIFF
--- a/src/roles/meta.js
+++ b/src/roles/meta.js
@@ -10,6 +10,7 @@ class MetaRole {
     }
     if (creep.memory.recharge) {
       var sources = creep.room.find(FIND_SOURCES_ACTIVE)
+      sources.sort((a, b) => a.pos.getRangeTo(a.room.controller) - b.pos.getRangeTo(b.room.controller))
       let idx = parseInt(creep.name[creep.name.length - 1], 36)
       var source = sources[idx % sources.length]
       if (!creep.pos.isNearTo(source)) {


### PR DESCRIPTION
The logic here is that we want creeps to start with the closer sources (that way the first creep spawned will be able to fill the controller up faster). To save CPU it looks for the controller rather than doing a check for all spawns (this is taking advantage of the fact that the quorum code prioritizes putting the spawn close to the controller).