### PR TITLE
Cached structure lookup

### DIFF
--- a/src/extends/room/structures.js
+++ b/src/extends/room/structures.js
@@ -1,12 +1,14 @@
+'use strict'
+
 Object.defineProperty(Room.prototype, 'structures', {
-  get: function() { 
-    if(!this._structures || _.isEmpty(this._structures)) {
-      this._all_structures = this.find(FIND_STRUCTURES)
-      this._structures = _.groupBy(this._all_structures, 'structureType');
-      this._structures.all = this._all_structures
+  get: function () { 
+    if (!this._structures || _.isEmpty(this._structures)) {
+      let allStructures = this.find(FIND_STRUCTURES)
+      this._structures = _.groupBy(allStructures, 'structureType')
+      this._structures.all = allStructures
     }
-    return this._structures;
+    return this._structures
   },
   enumerable: false,
   configurable: true
-});
+})

--- a/src/extends/room/structures.js
+++ b/src/extends/room/structures.js
@@ -1,0 +1,12 @@
+Object.defineProperty(Room.prototype, 'structures', {
+  get: function() { 
+    if(!this._structures || _.isEmpty(this._structures)) {
+      this._all_structures = this.find(FIND_STRUCTURES)
+      this._structures = _.groupBy(this._all_structures, 'structureType');
+      this._structures.all = this._all_structures
+    }
+    return this._structures;
+  },
+  enumerable: false,
+  configurable: true
+});

--- a/src/main.js
+++ b/src/main.js
@@ -30,6 +30,7 @@ require('extends_creep')
 require('extends_room_construction')
 require('extends_room_logistics')
 require('extends_room_spawning')
+require('extends_room_structures')
 require('extends_roomposition')
 
 var QosKernel = require('qos_kernel')


### PR DESCRIPTION
This cached the results of room.find in an easily accessed hash of structures. This makes it easy to get an array of a specific structure without using find or filter. 
The find and groupBy is called on first access and cached for the lifetime of the Room object
ex: `room.structures[STRUCTURE_TOWER]` returns an array of towers for the room
`room.structures.all` is a convenience array of all structures.