### PR TITLE
Merge Faster

### DIFF
--- a/.gitconsensus.yaml
+++ b/.gitconsensus.yaml
@@ -5,7 +5,7 @@ version: 2
 #
 
 # Minimum number of voters
-quorum: 2
+quorum: 3
 
 # Required percentage of "yes" votes (ignoring abstentions)
 threshold: 0.65

--- a/.gitconsensus.yaml
+++ b/.gitconsensus.yaml
@@ -11,7 +11,7 @@ quorum: 2
 threshold: 0.65
 
 # Number of hours after last action (commit or opening the pull request) before issue can be merged
-mergedelay: 12
+mergedelay: 6
 
 # Number of hours after last action (commit or opening the pull request) before issue is autoclosed
 timeout: 720


### PR DESCRIPTION
12 hours still seems slow, lets go even faster! Benefits include being able to patch bugs much quicker, rather than the bot being half dead while waiting on a patch.