### PR TITLE
Creep Control using "Clusters"

### DIFF
--- a/src/lib/cluster.js
+++ b/src/lib/cluster.js
@@ -1,0 +1,69 @@
+'use strict'
+
+class Cluster {
+  static clean () {
+    var clusters = Cluster.listAll()
+    for (var clustername of clusters) {
+      var cluster = new Cluster(clustername)
+      if (Memory.clusters[clustername].creeps.length <= 0) {
+        delete Memory.clusters[clustername]
+      }
+    }
+  }
+
+  static listAll () {
+    if (!Memory.clusters) {
+      return []
+    }
+    return Object.keys(Memory.clusters)
+  }
+
+  constructor (name, room = false) {
+    this.name = name
+    this.room = room
+    if (!Memory.clusters) {
+      Memory.clusters = {}
+    }
+    if (!Memory.clusters[name]) {
+      Memory.clusters[name] = {
+        'creeps': []
+      }
+    }
+    this.memory = Memory.clusters[name]
+    this.creeps = []
+    for (var creepname of this.memory.creeps) {
+      if (Game.creeps[creepname]) {
+        this.creeps.push(Game.creeps[creepname])
+        continue
+      }
+      if (room) {
+        if (!room.isQueued(creepname)) {
+          this.memory.creeps.indexOf.splice(this.memory.creeps.indexOf(creepname), 1)
+        }
+      } else if (!Room.isQueued(creepname)) {
+        this.memory.creeps.indexOf.splice(this.memory.creeps.indexOf(creepname), 1)
+      }
+    }
+  }
+
+  sizeCluster (role, quantity, options = {}, room = false) {
+    if (this.memory.creeps.length >= quantity) {
+      return true
+    }
+    var spawnroom = room || this.room
+    while (this.memory.creeps.length < quantity) {
+      this.memory.creeps.push(spawnroom.queueCreep(role, options))
+    }
+    return false
+  }
+
+  getCreeps () {
+    return this.creeps
+  }
+
+  forEach (creepAction) {
+    return this.getCreeps().forEach(creepAction)
+  }
+}
+
+module.exports = Cluster

--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -1,0 +1,14 @@
+
+let target = {};
+
+let loader = {
+    get(target, key, receiver) {
+      var classname = 'lib_' + key
+      if(!target[classname]) {
+        target[classname] = require(classname)
+      }
+      return target[classname]
+    }
+};
+
+module.exports = new Proxy({}, loader);

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,9 @@ require('thirdparty_roomvisual')
 var language = require('thirdparty_creeptalk_emoji')
 require('thirdparty_creeptalk')({'public': true, 'language': language})
 
+/* Make the quorum library code available globally */
+global.qlib = require('lib_loader')
+
 /* Extend built in objects */
 require('extends_creep')
 require('extends_room_construction')


### PR DESCRIPTION
This adds a small library called `Cluster` which allows developers to spawn and control groups of creeps from a single process.

It also provides a loader for the library code (accessible in the global `qlib` object). It can be used o access any library code (ie, `let myCluster = new qlib.cluster('harvesters')`).