### PR TITLE
Fix `getNextMissingStructureType`

### DIFF
--- a/src/extends/room/construction.js
+++ b/src/extends/room/construction.js
@@ -116,7 +116,7 @@ Room.prototype.getNextMissingStructureType = function () {
     if (skipStructures.indexOf(structureType) !== -1 || structureType === STRUCTURE_LINK) {
       continue
     }
-    if (nextLevelStructureCount[structureType] <= 0) {
+    if (!nextLevelStructureCount[structureType] || nextLevelStructureCount[structureType] <= 0) {
       continue
     }
     if (!structureCount[structureType] || structureCount[structureType] < nextLevelStructureCount[structureType]) {

--- a/src/extends/room/construction.js
+++ b/src/extends/room/construction.js
@@ -116,6 +116,9 @@ Room.prototype.getNextMissingStructureType = function () {
     if (skipStructures.indexOf(structureType) !== -1 || structureType === STRUCTURE_LINK) {
       continue
     }
+    if (nextLevelStructureCount[structureType] <= 0) {
+      continue
+    }
     if (!structureCount[structureType] || structureCount[structureType] < nextLevelStructureCount[structureType]) {
       return structureType
     }


### PR DESCRIPTION
The system was attempting to build structures when their needed amount was “zero” (so buildings it could not construct).