### PR TITLE
Add ability to set default energy for roles

### DIFF
--- a/src/extends/room/spawning.js
+++ b/src/extends/room/spawning.js
@@ -19,9 +19,6 @@ Room.prototype.queueCreep = function (role, options = {}) {
   if (!Memory.spawnqueue.index[this.name]) {
     Memory.spawnqueue.index[this.name] = {}
   }
-  if (!options.energy || options.energy > this.energyCapacityAvailable) {
-    options.energy = this.energyCapacityAvailable
-  }
   options.role = role
   Memory.spawnqueue.index[this.name][name] = options
   return name
@@ -51,7 +48,7 @@ Room.prototype.getQueuedCreep = function () {
 
   const options = Memory.spawnqueue.index[this.name][creeps[0]]
   const role = Creep.getRole(options.role)
-  const build = role.getBuild(options)
+  const build = role.getBuild(this, options)
   if (Creep.getCost(build) > this.energyAvailable) {
     return false
   }

--- a/src/roles/builder.js
+++ b/src/roles/builder.js
@@ -3,7 +3,8 @@
 const MetaRole = require('roles_meta')
 
 class Builder extends MetaRole {
-  getBuild(options) {
+  getBuild(room, options) {
+    this.setBuildDefaults(room, options)
     return Creep.buildFromTemplate([MOVE, CARRY, WORK], options.energy)
   }
 

--- a/src/roles/filler.js
+++ b/src/roles/filler.js
@@ -5,10 +5,12 @@ const MetaRole = require('roles_meta')
 class Filler extends MetaRole {
   constructor() {
     super()
+    this.defaultEnergy = 2200
     this.fillableStructures = [STRUCTURE_SPAWN, STRUCTURE_EXTENSION]
   }
 
-  getBuild(options) {
+  getBuild(room, options) {
+    this.setBuildDefaults(room, options)
     return Creep.buildFromTemplate([MOVE, CARRY, WORK], options.energy)
   }
 

--- a/src/roles/meta.js
+++ b/src/roles/meta.js
@@ -1,6 +1,19 @@
 'use strict'
 
 class MetaRole {
+
+  setBuildDefaults(room, options) {
+    if (!options.energy) {
+      if (this.defaultEnergy) {
+        options.energy = this.defaultEnergy
+      }
+    }
+    if (options.energy > room.energyCapacityAvailable) {
+      options.energy = room.energyCapacityAvailable
+    }
+  }
+
+
   recharge(creep) {
     if (creep.carry[RESOURCE_ENERGY] <= 0) {
       creep.memory.recharge = true

--- a/src/roles/replenisher.js
+++ b/src/roles/replenisher.js
@@ -5,6 +5,7 @@ const Filler = require('roles_filler')
 class Replenisher extends Filler {
   constructor() {
     super()
+    this.defaultEnergy = 1100
     this.fillableStructures = [STRUCTURE_TOWER]
   }
 }

--- a/src/roles/upgrader.js
+++ b/src/roles/upgrader.js
@@ -5,7 +5,8 @@ const MetaRole = require('roles_meta')
 const CONTROLLER_MESSAGE = '* Self Managed Code * quorum.tedivm.com * #quorum in Slack *'
 
 class Upgrader extends MetaRole {
-  getBuild(options) {
+  getBuild(room, options) {
+    this.setBuildDefaults(room, options)
     return Creep.buildFromTemplate([MOVE, CARRY, WORK], options.energy)
   }
 


### PR DESCRIPTION
Before this PR the system would scale creeps up to the size of the room if an energy amount was provided, and if an energy option was provided that was greater than the capacity of the room (due to lost extensions or buggy code calling it) it would fail to spawn and stall out the system.

This update allows a new property to be set on each role which defines the default value if one isn’t provided. It also automatically reduces that amount when pulling the creep from the queue if the room energyCapacityAvailable is lower than it. This effectively gives the role a "max" value it will autoscale to but which can be overridden when needed.

To do this the PR also adds the room as a parameter to the getBuild function, which will allow other room based logic to take place when deciding the build for a creep role.