### PR TITLE
Add copy as a dependency of deploy

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ gulp.task('copy', () => {
   })).pipe(gulp.dest('dist/'))
 })
 
-gulp.task('deploy', () => {
+gulp.task('deploy', ['copy'], () => {
   let config = require('./.screeps.json')
   let opts = config[args.server || 'main']
   let options = {}


### PR DESCRIPTION
This ensures copy finishes before deploy starts, otherwise it deploys an empty folder