### PR TITLE
Controller Timeout Prevention, other upgrader enhancements

### DIFF
--- a/src/extends/controller.js
+++ b/src/extends/controller.js
@@ -1,0 +1,7 @@
+
+StructureController.prototype.isTimingOut = function () {
+  if (!this.level || !CONTROLLER_DOWNGRADE[this.level]) {
+    return false
+  }
+  return CONTROLLER_DOWNGRADE[this.level] - this.ticksToDowngrade > 4000
+}

--- a/src/main.js
+++ b/src/main.js
@@ -32,6 +32,7 @@ require('thirdparty_creeptalk')({
 global.qlib = require('lib_loader')
 
 /* Extend built in objects */
+require('extends_controller')
 require('extends_creep')
 require('extends_room_construction')
 require('extends_room_logistics')

--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -44,6 +44,12 @@ class City extends kernel.process {
     this.launchCreepProcess('upgraders', 'upgrader', this.data.room, 5, {
       'priority': 5
     })
+    if (this.room.controller.isTimingOut()) {
+      this.launchCreepProcess('eupgrader', 'upgrader', this.data.room, 1, {
+        priority: 1,
+        energy: 200
+      })
+    }
   }
 }
 

--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -41,7 +41,8 @@ class City extends kernel.process {
     this.launchCreepProcess('fillers', 'filler', this.data.room, 2)
 
     // Launch upgraders
-    this.launchCreepProcess('upgraders', 'upgrader', this.data.room, 5, {
+    const upgraderQuantity = this.room.controller.level >= 8 ? 1 : 5
+    this.launchCreepProcess('upgraders', 'upgrader', this.data.room, upgraderQuantity, {
       'priority': 5
     })
     if (this.room.controller.isTimingOut()) {

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -107,7 +107,7 @@ class CityDefense extends kernel.process {
     if (room.controller.safeMode && room.controller.safeMode > 0) {
       return true
     }
-    if (room.controller.safeModeAvailable <= 0 || room.controller.safeModeCooldown) {
+    if (room.controller.safeModeAvailable <= 0 || room.controller.safeModeCooldown || room.controller.upgradeBlocked) {
       return false
     }
 

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -111,11 +111,12 @@ class CityDefense extends kernel.process {
       return false
     }
 
-    const spawns = room.find(FIND_MY_SPAWNS)
-    let spawn
-    for (spawn of spawns) {
-      const closest = spawn.pos.findClosestByRange(hostiles)
-      if (spawn.pos.getRangeTo(closest) < 5) {
+    let safeStructures = room.find(FIND_MY_SPAWNS)
+    safeStructures.push(room.controller)
+    let structure
+    for (structure of safeStructures) {
+      const closest = structure.pos.findClosestByRange(hostiles)
+      if (structure.pos.getRangeTo(closest) < 5) {
         // Trigger safemode
         Logger.log(`Activating safemode in ${this.data.room}`, LOG_ERROR)
         room.controller.activateSafeMode()


### PR DESCRIPTION
The newest controller changes make protecting the controller and keeping it from downgrading more important (as you can't initiate safemode if the controller is too far downgraded).

This update - 

* Launches a 1M1C1W creep to upgrade the controller if it downgrades by more than 4k ticks. A single round of upgrading should completely reset the downgrade timer (50 carry * 100 ticks per energy). This creep is also small enough to spawn even if the room's economy is stalled.

* Initiates sademode when a hostile creep gets too close to the controller.

* Drops number of upgraders to just one if the room is at RCL8.