### PR TITLE
Add Dedicated Local Mining

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
       "PathCache",
       "SCRIPT_VERSION",
       "sos",
+      "qlib",
       "SEGMENT_CONSTRUCTION",
       "LEVEL_BREAKDOWN",
       "STRUCTURE_LOADER",

--- a/src/extends/creep.js
+++ b/src/extends/creep.js
@@ -40,3 +40,10 @@ Creep.buildFromTemplate = function (template, energy) {
   }
   return parts
 }
+
+Creep.prototype.getCarryPercentage = function () {
+  if (this.carryCapacity <= 0) {
+    return 0
+  }
+  return _.sum(this.carry) / this.carryCapacity
+}

--- a/src/extends/creep/actions.js
+++ b/src/extends/creep/actions.js
@@ -28,6 +28,19 @@ Creep.prototype.recharge = function () {
     return true
   }
 
+  // If there is no storage check for containers.
+  const containers = _.filter(this.room.structures[STRUCTURE_CONTAINER], (a) => a.store[RESOURCE_ENERGY] > 0)
+  if (containers.length > 0) {
+    const container = this.pos.findClosestByRange(containers)
+    if (!this.pos.isNearTo(container)) {
+      this.moveTo(container)
+    }
+    if (this.pos.isNearTo(container)) {
+      this.withdraw(container, RESOURCE_ENERGY)
+    }
+    return true
+  }
+
   // As a last resort harvest energy from the active sources.
   const sources = this.room.find(FIND_SOURCES_ACTIVE)
   sources.sort((a, b) => a.pos.getRangeTo(a.room.controller) - b.pos.getRangeTo(b.room.controller))

--- a/src/extends/creep/actions.js
+++ b/src/extends/creep/actions.js
@@ -29,7 +29,7 @@ Creep.prototype.recharge = function () {
   }
 
   // If there is no storage check for containers.
-  const containers = _.filter(this.room.structures[STRUCTURE_CONTAINER], (a) => a.store[RESOURCE_ENERGY] > 0)
+  const containers = _.filter(this.room.structures[STRUCTURE_CONTAINER], (a) => a.store[RESOURCE_ENERGY] > 200)
   if (containers.length > 0) {
     const container = this.pos.findClosestByRange(containers)
     if (!this.pos.isNearTo(container)) {

--- a/src/extends/roomposition.js
+++ b/src/extends/roomposition.js
@@ -38,6 +38,46 @@ RoomPosition.prototype.getAdjacent = function () {
   return results
 }
 
+RoomPosition.prototype.getSteppableAdjacent = function (includeCreeps = false) {
+  return _.filter(this.getAdjacent(), function (pos) {
+    return pos.isSteppable(includeCreeps)
+  })
+}
+
+RoomPosition.prototype.isSteppable = function (includeCreeps = false) {
+  if (this.getTerrainAt() === 'wall') {
+    return false
+  }
+  const structures = this.lookFor(LOOK_STRUCTURES)
+  let structure
+  for (structure of structures) {
+    if (OBSTACLE_OBJECT_TYPES.indexOf(structure.structureType) >= 0) {
+      return false
+    }
+  }
+  if (includeCreeps) {
+    if (this.lookFor(LOOK_CREEPS).length > 0) {
+      return false
+    }
+  }
+  return true
+}
+
+RoomPosition.prototype.getMostOpenNeighbor = function () {
+  const steppable = this.getSteppableAdjacent()
+  let pos
+  let best
+  let score = 0
+  for (pos of steppable) {
+    const posScore = pos.getSteppableAdjacent().length
+    if (posScore > score) {
+      score = posScore
+      best = pos
+    }
+  }
+  return best
+}
+
 RoomPosition.prototype.isEdge = function () {
   return this.x === 49 || this.x === 0 || this.y === 49 || this.y === 0
 }

--- a/src/extends/source.js
+++ b/src/extends/source.js
@@ -1,0 +1,9 @@
+'use strict'
+
+Source.prototype.getMiningPosition = function () {
+  return this.pos.getMostOpenNeighbor()
+}
+
+Source.prototype.getLinkPosition = function () {
+  return this.getMiningPosition().getMostOpenNeighbor()
+}

--- a/src/extends/source.js
+++ b/src/extends/source.js
@@ -3,7 +3,3 @@
 Source.prototype.getMiningPosition = function () {
   return this.pos.getMostOpenNeighbor()
 }
-
-Source.prototype.getLinkPosition = function () {
-  return this.getMiningPosition().getMostOpenNeighbor()
-}

--- a/src/lib/cluster.js
+++ b/src/lib/cluster.js
@@ -38,10 +38,10 @@ class Cluster {
       }
       if (room) {
         if (!room.isQueued(creepname)) {
-          this.memory.creeps.indexOf.splice(this.memory.creeps.indexOf(creepname), 1)
+          this.memory.creeps.splice(this.memory.creeps.indexOf(creepname), 1)
         }
       } else if (!Room.isQueued(creepname)) {
-        this.memory.creeps.indexOf.splice(this.memory.creeps.indexOf(creepname), 1)
+        this.memory.creeps.splice(this.memory.creeps.indexOf(creepname), 1)
       }
     }
   }

--- a/src/lib/loader.js
+++ b/src/lib/loader.js
@@ -3,7 +3,7 @@ let target = {} // eslint-disable-line no-unused-vars
 
 let loader = {
   get (target, key, receiver) {
-    var classname = 'lib_' + key
+    var classname = 'lib_' + key.toLowerCase()
     if (!target[classname]) {
       target[classname] = require(classname)
     }

--- a/src/main.js
+++ b/src/main.js
@@ -40,6 +40,7 @@ require('extends_room_logistics')
 require('extends_room_spawning')
 require('extends_room_structures')
 require('extends_roomposition')
+require('extends_source')
 
 const QosKernel = require('qos_kernel')
 

--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -40,6 +40,13 @@ class City extends kernel.process {
     // Launch fillers
     this.launchCreepProcess('fillers', 'filler', this.data.room, 2)
 
+    // Launch mine
+    if (this.room.energyCapacityAvailable >= 800) {
+      this.launchChildProcess('mining', 'city_mine', {
+        'room': this.data.room
+      })
+    }
+
     // Launch upgraders
     const upgraderQuantity = this.room.controller.level >= 8 ? 1 : 5
     this.launchCreepProcess('upgraders', 'upgrader', this.data.room, upgraderQuantity, {

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -1,0 +1,94 @@
+'use strict'
+
+/**
+ * Mine sources in local room, placing energy in storage.
+ */
+
+class CityMine extends kernel.process {
+  constructor (...args) {
+    super(...args)
+    this.priority = PRIORITIES_CONSTRUCTION
+  }
+
+  main () {
+    if (!Game.rooms[this.data.room]) {
+      return this.suicide()
+    }
+    this.room = Game.rooms[this.data.room]
+
+    this.sources = this.room.find(FIND_SOURCES)
+    let source
+    for (source of this.sources) {
+      this.mineSource(source)
+    }
+  }
+
+  mineSource (source) {
+    // Identify where the miner should sit and any container should be built
+    const minerPos = source.getMiningPosition()
+
+    // Look for a container
+    const containers = _.filter(minerPos.lookFor(LOOK_STRUCTURES), (a) => a.structureType === STRUCTURE_CONTAINER)
+    const container = containers.length > 0 ? containers[0] : false
+
+    // Build container if it isn't there
+    let construction = false
+    if (!container) {
+      const constructionSites = minerPos.lookFor(LOOK_CONSTRUCTION_SITES)
+      if (constructionSites.length <= 0) {
+        this.room.createConstructionSite(minerPos, STRUCTURE_CONTAINER)
+      } else {
+        construction = constructionSites[0]
+      }
+    }
+
+    // Run miners.
+    const miners = new qlib.Cluster('miners_' + source.id, this.room)
+    miners.sizeCluster('miner', 1)
+    miners.forEach(function (miner) {
+      if (!miner.pos.isNearTo(source)) {
+        miner.moveTo(minerPos)
+        return
+      }
+      if (construction && miner.carry[RESOURCE_ENERGY]) {
+        miner.build(construction)
+        return
+      }
+      if (source.energy > 0) {
+        miner.harvest(source)
+      } else if (miner.carry[RESOURCE_ENERGY] && container && container.hits < container.hitsMax) {
+        miner.repair(container)
+      }
+    })
+
+    // If using containers spawn haulers
+    if (!container || !this.room.storage) {
+      Logger.highlight('bailing before haulers')
+      return
+    }
+
+    const haulers = new qlib.Cluster('haulers_' + source.id, this.room)
+    haulers.sizeCluster('hauler', 1)
+    haulers.forEach(function (hauler) {
+      if (hauler.getCarryPercentage() > 0.8) {
+        if (!hauler.pos.isNearTo(hauler.room.storage)) {
+          hauler.moveTo(hauler.room.storage)
+        }
+        if (hauler.pos.isNearTo(hauler.room.storage)) {
+          hauler.transfer(hauler.room.storage, RESOURCE_ENERGY)
+        }
+        return
+      }
+      if (!hauler.pos.isNearTo(container)) {
+        hauler.moveTo(container)
+      }
+      if (hauler.pos.isNearTo(container)) {
+        if (container.store[RESOURCE_ENERGY]) {
+          hauler.withdraw(container, RESOURCE_ENERGY)
+        }
+      }
+    })
+  }
+}
+
+module.exports = CityMine

--- a/src/roles/hauler.js
+++ b/src/roles/hauler.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const MetaRole = require('roles_meta')
+
+class Hauler extends MetaRole {
+  constructor () {
+    super()
+    this.defaultEnergy = 1200
+  }
+
+  getBuild (room, options) {
+    this.setBuildDefaults(room, options)
+    return Creep.buildFromTemplate([MOVE, CARRY], options.energy)
+  }
+}
+
+module.exports = Hauler

--- a/src/roles/miner.js
+++ b/src/roles/miner.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const MetaRole = require('roles_meta')
+
+class Miner extends MetaRole {
+  constructor () {
+    super()
+    this.defaultEnergy = 800
+  }
+
+  getBuild (room, options) {
+    this.setBuildDefaults(room, options)
+    const base = [MOVE, CARRY, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE]
+    if (options.energy >= 800) {
+      return base
+    }
+    return Creep.buildFromTemplate(base, options.energy)
+  }
+}
+
+module.exports = Miner


### PR DESCRIPTION
This upgrade creates a new `CityMining` program that manages local mining. It starts once the room can support 800 energy creeps, using the existing behavior before then.

This initial version uses container mining. There is some infrastructure available for figuring out the location of the future links, but at the moment that is considered a future feature.