### PR TITLE
tower healing bugfix- pos.roomName instead of pos.room.name

### DIFF
--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -78,7 +78,7 @@ class CityDefense extends kernel.process {
     if (this.data.healTarget !== undefined) {
       const healTarget = Game.getObjectById(this.data.healTarget)
       if (healTarget &&
-        (healTarget.pos.room.name === this.data.room) &&
+        (healTarget.pos.roomName === this.data.room) &&
         (healTarget.hits < healTarget.hitsMax)) {
         healFunc(healTarget)
         return


### PR DESCRIPTION
Stacktrace from console - 

```
city_defense: TypeError: Cannot read property 'name' of undefined
at CityDefense.fireTowers (programs_city_defense:81:29)
at CityDefense.main (programs_city_defense:42:12)
at CityDefense.run (qos_process:103:10)
at QosKernel.run (qos_kernel:73:24)
at Object.module.exports.loop (main:49:10)
at __module (__mainLoop:1:52)
at __mainLoop:2:3
at sigintHandlersWrap (vm.js:32:31)
at sigintHandlersWrap (vm.js:73:12)
at ContextifyScript.Script.runInContext (vm.js:31:12)
```