### PR TITLE
Reduce starting upgrader quantity to 3 at practical room level 6

### DIFF
--- a/src/extends/room/control.js
+++ b/src/extends/room/control.js
@@ -13,7 +13,8 @@ let roomLevelOptions = {
   },
   5: {},
   6: {
-    'EXTRACT_MINERALS': true
+    'EXTRACT_MINERALS': true,
+    'UPGRADERS_QUANTITY': 3
   },
   7: {},
   8: {


### PR DESCRIPTION
Because of the size of the upgraders the storage is drained considerably while they work. This means the system is basically doing a big burst of upgrading, stopping to rebuild the energy buffer, and then upgrading again.

Reducing to three upgraders will mean less upgraders run at once but upgraders should be running more often in general.

In the event that energy builds up higher (such as when remote mining gets enabled) the system already is already programmed to spawn an extra two upgraders on top of the ones it already spawns.