### PR TITLE
Bugfix- don't modify original "defaults" object, return on random move

### DIFF
--- a/src/extends/creep/movement.js
+++ b/src/extends/creep/movement.js
@@ -9,12 +9,12 @@ const travelToDefaults = {
   'ignoreStuck': false
 }
 
-Creep.prototype.travelTo = function (pos, opts) {
+Creep.prototype.travelTo = function (pos, opts = {}) {
   if (this.fatigue) {
     return ERR_TIRED
   }
 
-  const moveToOpts = Object.assign(travelToDefaults, opts)
+  const moveToOpts = Object.assign({}, travelToDefaults, opts)
 
   // Compute max operations based on number of rooms.
   if (typeof moveToOpts.maxOps === 'undefined') {
@@ -45,7 +45,7 @@ Creep.prototype.travelTo = function (pos, opts) {
       if (this.memory._sc > struckRerouteThreshold) {
         const steppable = this.pos.getSteppableAdjacent(true)
         if (steppable.length > 0) {
-          this.move(this.pos.getDirectionTo(_.shuffle(steppable)[0]))
+          return this.move(this.pos.getDirectionTo(_.shuffle(steppable)[0]))
         }
       }
     }


### PR DESCRIPTION
This resolves two bugs-

* The original code was modifying the list of default options, which made it so future calls to `travelTo` would include those changes (even when they should).

* The "random move" code when stuck was not returning after the `move` call, so it was basically being overwritten by the later call to moveTo.