### PR TITLE
Added transferAll and recycle actions to creep

### DIFF
--- a/src/extends/creep/actions.js
+++ b/src/extends/creep/actions.js
@@ -58,3 +58,62 @@ Creep.prototype.recharge = function () {
   }
   return true
 }
+
+Creep.prototype.recycle = function () {
+  let storage = this.room.storage
+  if (!storage && this.room.terminal) {
+    storage = this.room.terminal
+  }
+
+  // Empty creep of all resources, dump them in storage.
+  if (this.getCarryPercentage() > 0) {
+    if (storage) {
+      if (this.pos.isNearTo(storage)) {
+        this.transferAll(storage)
+      } else {
+        this.travelTo(storage)
+      }
+      return
+    }
+  }
+
+  // No spawn - time to suicide.
+  if (!this.room.structures[STRUCTURE_SPAWN]) {
+    this.suicide()
+    return
+  }
+
+  // Identify spawn closest to storage, to make reclaimed energy easier to store.
+  let spawn = false
+  if (storage) {
+    spawn = storage.pos.findClosestByRange(this.room.structures[STRUCTURE_SPAWN])
+  } else {
+    spawn = this.room.structures[STRUCTURE_SPAWN]
+  }
+
+  // Pick the location immediately above the spawn and recycle there.
+  const suicideBooth = new RoomPosition(spawn.pos.x, spawn.pos.y - 1, spawn.room.name)
+  if (this.pos.getRangeTo(suicideBooth) > 0) {
+    this.travelTo(suicideBooth)
+  } else {
+    spawn.recycleCreep(this)
+  }
+}
+
+Creep.prototype.transferAll = function (target) {
+  if (this.getCarryPercentage() <= 0) {
+    return ERR_NOT_ENOUGH_RESOURCES
+  }
+  if (!this.pos.isNearTo(target)) {
+    return ERR_NOT_IN_RANGE
+  }
+  const resources = Object.keys(this.carry)
+  let resource
+  for (resource of resources) {
+    if (this.carry[resource] > 0) {
+      return this.transfer(target, resource)
+    }
+  }
+  // this line should never get reached
+  return false
+}

--- a/src/extends/creep/actions.js
+++ b/src/extends/creep/actions.js
@@ -88,7 +88,7 @@ Creep.prototype.recycle = function () {
   if (storage) {
     spawn = storage.pos.findClosestByRange(this.room.structures[STRUCTURE_SPAWN])
   } else {
-    spawn = this.room.structures[STRUCTURE_SPAWN]
+    spawn = this.room.structures[STRUCTURE_SPAWN][0]
   }
 
   // Pick the location immediately above the spawn and recycle there.

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -69,6 +69,9 @@ class CityMine extends kernel.process {
     const haulers = new qlib.Cluster('haulers_' + source.id, this.room)
     haulers.sizeCluster('hauler', 1)
     haulers.forEach(function (hauler) {
+      if (hauler.ticksToLive < 50) {
+        return hauler.recycle()
+      }
       if (hauler.getCarryPercentage() > 0.8) {
         if (!hauler.pos.isNearTo(hauler.room.storage)) {
           hauler.travelTo(hauler.room.storage)

--- a/src/roles/builder.js
+++ b/src/roles/builder.js
@@ -9,6 +9,9 @@ class Builder extends MetaRole {
   }
 
   manageCreep (creep) {
+    if (creep.ticksToLive < 50) {
+      return this.recycle()
+    }
     if (creep.recharge()) {
       return
     }

--- a/src/roles/filler.js
+++ b/src/roles/filler.js
@@ -19,6 +19,9 @@ class Filler extends MetaRole {
   }
 
   manageCreep (creep) {
+    if (creep.ticksToLive < 50) {
+      return this.recycle()
+    }
     if (creep.recharge()) {
       return
     }


### PR DESCRIPTION
This adds two actions-

* `transferAll` - takes any target and will transfer all resources to that target. Otherwise it works just like `transfer` (including returning the same error codes).

* `recycle` - this action first uses `transferAll` to empty any resources the creep is holding. It then gets itself to a location between the spawn and storage and has the spawn recycle the creep. If no spawn is available in the room the creep will suicide instead.

This then runs the `recycle` action on all `fillers` and `haulers` once they hit less than 50 ticks to live.

resolves #93