### PR TITLE
Use try/catch to ensure `shift` doesn't fail due to program error

### DIFF
--- a/src/qos/scheduler.js
+++ b/src/qos/scheduler.js
@@ -59,8 +59,13 @@ class Scheduler {
       if (!this.memory.processes.index[pid]) {
         continue
       }
-      const priority = this.getPriorityForPid(pid)
-      this.memory.processes.queues[priority].push(pid)
+      try {
+        const priority = this.getPriorityForPid(pid)
+        this.memory.processes.queues[priority].push(pid)
+      } catch (err) {
+        delete this.memory.processes.index[pid]
+        Logger.log(err, LOG_ERROR)
+      }
     }
     this.memory.processes.completed = []
   }


### PR DESCRIPTION
Besides catching (and logging) the error this PR also removes the offending program from the process queue.