### PR TITLE
Prime `target` with random exit during final check

### DIFF
--- a/src/extends/room/intel.js
+++ b/src/extends/room/intel.js
@@ -206,6 +206,7 @@ Room.getScoutTarget = function (creep) {
 
   if (!target) {
     const adjacent = _.shuffle(_.values(Game.map.describeExits(creep.room.name)))
+    target = adjacent[0]
     let oldest = 0
     let testRoom
     for (testRoom of adjacent) {


### PR DESCRIPTION
This makes sure that a target scouting room is always picked.