### PR TITLE
Enable `sos.lib.monitor` statistic gathering

### DIFF
--- a/src/programs/meta/monitor.js
+++ b/src/programs/meta/monitor.js
@@ -1,0 +1,20 @@
+'use strict'
+
+/**
+ * This process runs in the background to monitor how often a specific priority runs. This in turn can feed into other
+ * systems (ex, adding remote mines when there is available CPU).
+ */
+
+class MetaMonitor extends kernel.process {
+  getPriority () {
+    return this.data.priority
+  }
+  getDescriptor () {
+    return this.data.priority
+  }
+  main () {
+    sos.lib.monitor.markRun(this.data.priority)
+  }
+}
+
+module.exports = MetaMonitor

--- a/src/programs/player.js
+++ b/src/programs/player.js
@@ -24,6 +24,16 @@ class Player extends kernel.process {
         })
       }
     }
+
+    const monitorPriorities = _.uniq([
+      PRIORITIES_CREEP_DEFAULT,
+      PRIORITIES_DEFAULT
+    ])
+    for (let priority of monitorPriorities) {
+      this.launchChildProcess(`pmonitor_${priority}`, 'meta_monitor', {
+        'priority': priority
+      })
+    }
   }
 }
 


### PR DESCRIPTION
The `sos.lib.monitor` package (part of the sos-library package in the third party tools) records how often a process running at a specified priority will run. It's designed to resemble unix "load" values, which are three numbers representing the system load over 1, 5, and 15 minute intervals with higher numbers signifying higher load on the system. 

For this system the load values are calculated by recording how often a specific process runs. If the process runs every tick the load value is "1", if it runs every other tick that value will be "2", and if it runs two out of three times the load will be "1.5". This PR enables the system at the default priorities for creep and non creep processes (which means launching two background processes, but these are extremely low cpu).

Just like with unix load values come in three intervals and always include the most recent tick.

`short` - 200 to 300 ticks
`medium` - 1000 to 1100 ticks
`long` - 3000 3100 ticks

Comparing the three values is useful for determining trends and determining whether the system has the CPU to perform certain actions.
