### PR TITLE
Add getClusterSize, which takes into account spawning creeps

### DIFF
--- a/src/lib/cluster.js
+++ b/src/lib/cluster.js
@@ -5,7 +5,7 @@ class Cluster {
     var clusters = Cluster.listAll()
     for (var clustername of clusters) {
       var cluster = new Cluster(clustername)
-      if (cluster.getCreeps().length <= 0) {
+      if (cluster.getClusterSize() <= 0) {
         delete Memory.clusters[clustername]
       }
     }
@@ -45,6 +45,10 @@ class Cluster {
         this.memory.creeps.splice(this.memory.creeps.indexOf(creepname), 1)
       }
     }
+  }
+
+  getClusterSize () {
+    return this.memory.creeps.length
   }
 
   sizeCluster (role, quantity, options = {}, room = false) {

--- a/src/programs/city/extract.js
+++ b/src/programs/city/extract.js
@@ -78,7 +78,7 @@ class CityExtract extends kernel.process {
 
     // If there is nothing left to extract and the existing creeps have recycled themselves
     if (canExtract) {
-      if (frackers.length <= 0 && haulerCluster.getCreeps().length <= 0) {
+      if (frackers.length <= 0 && haulerCluster.getClusterSize() <= 0) {
         this.suicide()
       }
     }

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -67,7 +67,7 @@ class CityMine extends kernel.process {
     // Check if a replacement miner is needed and spawn it early
     const minerCreeps = miners.getCreeps()
     let minerQuantity = 1
-    if (minerCreeps.length === 1 && minerCreeps[0].ticksToLive < 60) {
+    if (miners.getClusterSize() === 1 && minerCreeps[0].ticksToLive < 60) {
       minerQuantity = 2
     }
 


### PR DESCRIPTION
This may fix the extraction bug (it may not either, but it's still good). It will also prevent new clusters from having issues and potentially being "cleaned".