### PR TITLE
Don't add spawning creeps to cluster creep group

### DIFF
--- a/src/lib/cluster.js
+++ b/src/lib/cluster.js
@@ -33,8 +33,10 @@ class Cluster {
     this.creeps = []
     for (var creepname of this.memory.creeps) {
       if (Game.creeps[creepname]) {
-        Game.creeps[creepname].cluster = this
-        this.creeps.push(Game.creeps[creepname])
+        if (!Game.creeps[creepname].spawning) {
+          Game.creeps[creepname].cluster = this
+          this.creeps.push(Game.creeps[creepname])
+        }
         continue
       }
       if (room) {


### PR DESCRIPTION
This will make it so the `cluster.getCreeps` functions only return *usable* creeps. The `getClusterSize` function still returns the total number of creeps (live, spawning, and in the queue).