### PR TITLE
More pathfinding

### DIFF
--- a/src/extends/creep/movement.js
+++ b/src/extends/creep/movement.js
@@ -16,7 +16,21 @@ Creep.prototype.travelTo = function (pos, opts = {}) {
     return ERR_TIRED
   }
 
+  // Allow objects with a pos value to be passed in as destinations.
+  if (pos.pos) {
+    pos = pos.pos
+  }
+
   const moveToOpts = Object.assign({}, travelToDefaults, opts)
+
+  if (typeof moveToOpts.maxRooms === 'undefined') {
+    // If the destination is in the same room as the creep restrict pathfinding to that room.
+    if (this.room.name !== pos.roomName) {
+      moveToOpts.maxRooms = 1
+    } else {
+      moveToOpts.maxRooms = 16
+    }
+  }
 
   // Compute max operations based on number of rooms.
   if (typeof moveToOpts.maxOps === 'undefined') {

--- a/src/extends/room/intel.js
+++ b/src/extends/room/intel.js
@@ -188,6 +188,9 @@ Room.requestIntel = function (roomname) {
     Game.rooms[roomname].saveIntel()
     return
   }
+  if (!Game.map.isRoomAvailable(roomname)) {
+    return
+  }
   if (!Memory.intel) {
     Memory.intel = {
       buffer: {},
@@ -209,6 +212,11 @@ Room.getScoutTarget = function (creep) {
     let oldest = false
     let testRoom
     for (testRoom of targetRooms) {
+      // Filter out invalid rooms
+      if (!Game.map.isRoomAvailable(testRoom)) {
+        continue
+      }
+
       // Filter out rooms that already have a scount creep assigned to them.
       if (assignedRooms.indexOf(testRoom) >= 0) {
         if (Game.creeps[Memory.intel.active[testRoom]]) {
@@ -237,6 +245,9 @@ Room.getScoutTarget = function (creep) {
     let oldest = 0
     let testRoom
     for (testRoom of adjacent) {
+      if (!Game.map.isRoomAvailable(testRoom)) {
+        continue
+      }
       const roominfo = Room.getIntel(testRoom)
       let age
       if (!roominfo) {

--- a/src/extends/room/meta.js
+++ b/src/extends/room/meta.js
@@ -96,3 +96,10 @@ Room.isSourcekeeper = function (name) {
   let yMod = coords.y % 10
   return xMod >= 4 && xMod <= 6 && yMod >= 4 && yMod <= 6
 }
+
+Room.isHallway = function (name) {
+  const coords = Room.getCoordinates(name)
+  let xMod = coords.x % 10
+  let yMod = coords.y % 10
+  return xMod === 0 || yMod === 0
+}

--- a/src/extends/room/movement.js
+++ b/src/extends/room/movement.js
@@ -94,6 +94,24 @@ Room.getStructuresCostmatrix = function (roomname, opts) {
     }
   }
 
+  // Penalize exit squares to prevent accidental room changes
+  if (!opts.ignoreExits) {
+    for (let n = 0; n <= 49; n++) {
+      if (Game.map.getTerrainAt(0, n) === 'plain') {
+        cm.set(0, n, 15)
+      }
+      if (Game.map.getTerrainAt(49, n) === 'plain') {
+        cm.set(49, n, 15)
+      }
+      if (Game.map.getTerrainAt(n, 0) === 'plain') {
+        cm.set(n, 0, 15)
+      }
+      if (Game.map.getTerrainAt(n, 49) === 'plain') {
+        cm.set(n, 49, 15)
+      }
+    }
+  }
+
   sos.lib.cache.set(cacheLabel, cm.serialize(), {
     persist: true,
     maxttl: 3000,

--- a/src/lib/cluster.js
+++ b/src/lib/cluster.js
@@ -78,6 +78,9 @@ class Cluster {
         creepAction(creep)
       } catch (err) {
         Logger.log(err, LOG_ERROR)
+        if (err.stack) {
+          Logger.log(err.stack, LOG_ERROR)
+        }
       }
     }
   }

--- a/src/lib/map.js
+++ b/src/lib/map.js
@@ -1,0 +1,36 @@
+
+module.exports.findRoute = function (fromRoom, toRoom, opts = {}) {
+  if (!opts.routeCallback) {
+    opts.routeCallback = function (toRoom, fromRoom) {
+      return module.exports.getRoomScore(toRoom)
+    }
+  }
+  return Game.map.findRoute(fromRoom, toRoom, opts)
+}
+
+const PATH_WEIGHT_HALLWAY = 1
+const PATH_WEIGHT_SOURCEKEEPER = 1
+const PATH_WEIGHT_OWN = 1
+const PATH_WEIGHT_NEUTRAL = 3
+const PATH_WEIGHT_HOSTILE = 10
+const PATH_WEIGHT_HOSTILE_RESERVATION = 5
+
+module.exports.getRoomScore = function (roomName) {
+  if (!Game.map.isRoomAvailable(roomName)) {
+    return Infinity
+  }
+  if (Room.isSourcekeeper(roomName)) {
+    return PATH_WEIGHT_SOURCEKEEPER
+  }
+  if (Room.isHallway(roomName)) {
+    return PATH_WEIGHT_HALLWAY
+  }
+  const roomIntel = Room.getIntel(roomName)
+  if (roomIntel && roomIntel[INTEL_OWNER]) {
+    if (roomIntel[INTEL_OWNER] === USERNAME) {
+      return PATH_WEIGHT_OWN
+    }
+    return roomIntel[INTEL_LEVEL] ? PATH_WEIGHT_HOSTILE : PATH_WEIGHT_HOSTILE_RESERVATION
+  }
+  return PATH_WEIGHT_NEUTRAL
+}


### PR DESCRIPTION
* Added a `findRoute` wrapper that injects a custom room scoring function if one isn't supplied. This entry point can also be used to assist a future caching upgrade.

* Use findRoute wrapper to limit rooms used by travelTo pathfinder. This can be overridden with the `direct` option on travelTo.

* Penalize exit tiles to prevent accidental room changes.

* If `maxRooms` isn't provided this will set it to one if the destination is in the same room (thus preventing a creep from leaving that room) or 16.

* Utilize `Game.map.isRoomAvailable` to prevent intel and pathfinders from using rooms that are out of bounds.

* Some better error handling.
