### PR TITLE
Reduce reservation level at which reservers are spawned

### DIFF
--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -163,7 +163,7 @@ class CityMine extends kernel.process {
     const controller = this.mine.controller
     const timeout = controller.reservation ? controller.reservation.ticksToEnd : 0
     let quantity = 0
-    if (timeout < 4000) {
+    if (timeout < 3500) {
       quantity = Math.min(this.room.getRoomSetting('RESERVER_COUNT'), controller.pos.getSteppableAdjacent().length)
     }
 


### PR DESCRIPTION
Drop the limit from 4000 to 3500. This should save some energy due to hitting the reservation caps.