### PR TITLE
[bugfix] Return early if there are no active sources

### DIFF
--- a/src/extends/creep/actions.js
+++ b/src/extends/creep/actions.js
@@ -47,6 +47,11 @@ Creep.prototype.recharge = function () {
     return true
   }
   const sources = this.room.find(FIND_SOURCES_ACTIVE)
+  if (sources.length <= 0) {
+    // Still returning true since energy is still needed
+    return true
+  }
+
   sources.sort((a, b) => a.pos.getRangeTo(a.room.controller) - b.pos.getRangeTo(b.room.controller))
   const idx = parseInt(this.name[this.name.length - 1], 36)
   const source = sources[idx % sources.length]


### PR DESCRIPTION
To replicate bug-

* Storage must be empty.
* All containers must be empty.
* Creep must have work parts.
* All sources  must be out of energy.

When all those conditions are met an error will occur. This PR fixes it.