### PR TITLE
Expand to up to three mines per room

### DIFF
--- a/src/extends/room/control.js
+++ b/src/extends/room/control.js
@@ -9,7 +9,7 @@ let roomLevelOptions = {
   },
   2: {},
   3: {
-    'REMOTE_MINES': true
+    'REMOTE_MINES': 1
   },
   4: {
     'DEDICATED_MINERS': true,
@@ -23,10 +23,12 @@ let roomLevelOptions = {
     'RESERVER_COUNT': 2
   },
   7: {
-    'RESERVER_COUNT': 1
+    'RESERVER_COUNT': 1,
+    'REMOTE_MINES': 2
   },
   8: {
-    'UPGRADERS_QUANTITY': 1
+    'UPGRADERS_QUANTITY': 1,
+    'REMOTE_MINES': 3
   }
 }
 

--- a/src/extends/room/territory.js
+++ b/src/extends/room/territory.js
@@ -18,6 +18,8 @@ Room.getCities = function () {
 
 Room.addCity = function (roomName) {
   Memory.territory[roomName] = {}
+  Logger.log(`Adding city ${roomName}`)
+  qlib.events.recordEvent('addcity')
 }
 
 Room.prototype.getMines = function () {
@@ -38,6 +40,8 @@ Room.prototype.addMine = function (mine) {
     Memory.territory[this.name].mines = []
   }
   Memory.territory[this.name].mines.push(mine)
+  Logger.log(`Adding mine from ${this.name} to ${mine}`)
+  qlib.events.recordEvent('addmine')
 }
 
 Room.getMineOwner = function (mine) {

--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -1,0 +1,26 @@
+
+class Events {
+  constructor () {
+    if (!Memory.events) {
+      Memory.events = {}
+    }
+    this.memory = Memory.events
+  }
+
+  getEventTime (event) {
+    if (!this.memory[event]) {
+      return 0
+    }
+    return this.memory[event]
+  }
+
+  recordEvent (event) {
+    this.memory[event] = Game.time
+  }
+
+  getTimeSinceEvent (event) {
+    return Game.time - this.getEventTime()
+  }
+}
+
+module.exports = new Events()

--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -54,11 +54,20 @@ class City extends kernel.process {
 
     if (this.room.getRoomSetting('REMOTE_MINES')) {
       let remoteMines = this.room.getMines()
-      if (remoteMines.length <= 0) {
-        let mine = this.room.selectNextMine()
-        this.room.addMine(mine)
-        remoteMines = this.room.getMines
+
+      if (remoteMines.length <= 3) {
+        const cpuUsage = sos.lib.monitor.getPriorityRunStats(PRIORITIES_CREEP_DEFAULT)
+        if (cpuUsage && cpuUsage['long'] <= 1.25) {
+          if (remoteMines.length <= 0 || !this.data.lastadd || Game.time - this.data.lastadd >= 2000) {
+            Logger.log(`Adding mine to ${this.data.room}`)
+            let mine = this.room.selectNextMine()
+            this.room.addMine(mine)
+            remoteMines = this.room.getMines()
+            this.data.lastadd = Game.time
+          }
+        }
       }
+
       let mineRoomName
       for (mineRoomName of remoteMines) {
         this.launchChildProcess(`mine_${mineRoomName}`, 'city_mine', {

--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -52,19 +52,16 @@ class City extends kernel.process {
       })
     }
 
-    if (this.room.getRoomSetting('REMOTE_MINES')) {
+    const mineCount = this.room.getRoomSetting('REMOTE_MINES')
+    const lastAdd = qlib.events.getTimeSinceEvent('addmine')
+    if (mineCount && lastAdd >= 2000) {
       let remoteMines = this.room.getMines()
-
-      if (remoteMines.length <= 3) {
+      if (remoteMines.length <= mineCount) {
         const cpuUsage = sos.lib.monitor.getPriorityRunStats(PRIORITIES_CREEP_DEFAULT)
         if (cpuUsage && cpuUsage['long'] <= 1.25) {
-          if (remoteMines.length <= 0 || !this.data.lastadd || Game.time - this.data.lastadd >= 2000) {
-            Logger.log(`Adding mine to ${this.data.room}`)
-            let mine = this.room.selectNextMine()
-            this.room.addMine(mine)
-            remoteMines = this.room.getMines()
-            this.data.lastadd = Game.time
-          }
+          let mine = this.room.selectNextMine()
+          this.room.addMine(mine)
+          remoteMines = this.room.getMines()
         }
       }
 


### PR DESCRIPTION
All rooms will mine at least one remote (as it currently it). From there they will mine another two rooms (one at a time, with a delay of 2000 ticks between new mining operations) if there is enough CPU available.