### PR TITLE
Protect against low bucket

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -52,6 +52,10 @@ require('extends_source')
 const QosKernel = require('qos_kernel')
 
 module.exports.loop = function () {
+  if (Game.cpu.bucket < 500) {
+    Logger.log('Extremely low bucket - aborting script run at start of loop', LOG_FATAL)
+    return
+  }
   const kernel = new QosKernel()
   kernel.start()
   kernel.run()

--- a/src/qos/kernel.js
+++ b/src/qos/kernel.js
@@ -4,6 +4,7 @@ const Scheduler = require('qos_scheduler')
 const Performance = require('qos_performance')
 const Process = require('qos_process')
 
+const BUCKET_EMERGENCY = 1000
 const BUCKET_FLOOR = 2000
 const BUCKET_CEILING = 9500
 const CPU_BUFFER = 130
@@ -101,6 +102,10 @@ class QosKernel {
   getCpuLimit () {
     if (Game.cpu.bucket > BUCKET_CEILING) {
       return Game.cpu.tickLimit - CPU_BUFFER
+    }
+
+    if (Game.cpu.bucket < BUCKET_EMERGENCY) {
+      return 0
     }
 
     if (Game.cpu.bucket < BUCKET_FLOOR) {


### PR DESCRIPTION
Adds protection in two new areas-

* Top of the `loop` function now contains a check against extremely low (less than 500) buckets. This is like the existing check at the top of `main.js` except it doesn't just run on global resets.

* The kernel will refuse to run processes if the bucket is below 1000, although it will perform other functions.