### PR TITLE
Use containers to allow remote mining to rooms with no storage

### DIFF
--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -96,11 +96,6 @@ class CityMine extends kernel.process {
       }
     })
 
-    // If using containers spawn haulers
-    if (!container || !this.room.storage) {
-      return
-    }
-
     let storage = false
     if (this.room.storage) {
       storage = this.room.storage
@@ -119,7 +114,7 @@ class CityMine extends kernel.process {
           if (spawns.length > 1) {
             spawns.sort((a, b) => a.energy - b.energy)
           }
-          storage = containers[0]
+          storage = spawns[0]
         }
       }
     }
@@ -138,13 +133,15 @@ class CityMine extends kernel.process {
         this.data.ssp = {}
       }
       if (!this.data.ssp[source.id]) {
-        this.data.ssp[source.id] = this.room.findPath(this.room.storage, source, {
-          ignoreCreeps: true,
-          maxOps: 6000
-        }).length
+        if (this.room.storage) {
+          this.data.ssp[source.id] = this.room.findPath(this.room.storage, source, {
+            ignoreCreeps: true,
+            maxOps: 6000
+          }).length
+        }
       }
-      distance = this.data.ssp[source.id]
-      const carryAmount = (Math.ceil((this.data.ssp[source.id] * 20) / 100) * 100) + 200
+      distance = this.data.ssp[source.id] ? this.data.ssp[source.id] : 80
+      const carryAmount = (Math.ceil((distance * 20) / 100) * 100) + 200
       const carryCost = BODYPART_COST['move'] + BODYPART_COST['carry']
       const maxEnergy = carryCost * (MAX_CREEP_SIZE / 2)
       let energy = (carryAmount / CARRY_CAPACITY) * carryCost // 50 carry == 1m1c == 100 energy


### PR DESCRIPTION
Without this remote mining fails at early levels because haulers do not spawn to ferry the energy back.