### PR TITLE
Cache spook target in memory

### DIFF
--- a/src/roles/spook.js
+++ b/src/roles/spook.js
@@ -87,6 +87,7 @@ class Spook extends MetaRole {
       target = creep.memory.starget
     } else {
       target = Room.getScoutTarget(creep)
+      creep.memory.starget = target
     }
     if (creep.travelTo(new RoomPosition(25, 25, target), {range: 23}) === ERR_NO_PATH) {
       delete creep.memory.starget


### PR DESCRIPTION
All of the code was there to use the value in the creep's memory but it wasn't actually being saved there. This should drop the `spook` cpu usage considerably.