### PR TITLE
Reboot when there are no fillers (as opposed to no creeps at all)

### DIFF
--- a/src/programs/city/reboot.js
+++ b/src/programs/city/reboot.js
@@ -15,7 +15,8 @@ class CityReboot extends kernel.process {
       return this.suicide()
     }
     this.room = Game.rooms[this.data.room]
-    if (this.room.find(FIND_MY_CREEPS).length <= 0) {
+    const fillers = this.room.find(FIND_MY_CREEPS, {filter: (creep) => creep.name.startsWith('filler')})
+    if (fillers.length <= 0) {
       this.launchCreepProcess('rebooter', 'filler', this.data.room, 2, {
         priority: 1,
         energy: 300


### PR DESCRIPTION
This adds a simple filter against the creep find statement which checks for creeps with names that start with `filler`. This way if the room is filled with other creeps but has no fillers it will still spawn the emergency fillers rather than waiting.