### PR TITLE
Add `getCluster` to `Process` and use it

### DIFF
--- a/src/programs/city/extract.js
+++ b/src/programs/city/extract.js
@@ -15,8 +15,8 @@ class CityExtract extends kernel.process {
     const mineral = this.room.find(FIND_MINERALS)[0]
     const storage = this.room.terminal ? this.room.terminal : this.room.storage
     const canExtract = extractor && mineral.mineralAmount > 0 && !mineral.ticksToRegeneration
-    const frackerCluster = new qlib.Cluster('Extract_frackers_' + this.data.room, this.room)
-    const haulerCluster = new qlib.Cluster('Extract_Haulers_' + this.data.room, this.room)
+    const frackerCluster = this.getCluster('frackers', this.room)
+    const haulerCluster = this.getCluster('haulers', this.room)
     const frackers = frackerCluster.getCreeps()
     const frackersToEmpty = _.filter(frackers, function (fracker) {
       if (!fracker.pos.isNearTo(mineral)) {

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -70,7 +70,7 @@ class CityMine extends kernel.process {
     }
 
     // Run miners.
-    const miners = new qlib.Cluster('miners_' + source.id, this.room)
+    const miners = this.getCluster(`miners_${source.id}`, this.room)
 
     // Check if a replacement miner is needed and spawn it early
     const minerCreeps = miners.getCreeps()
@@ -128,7 +128,7 @@ class CityMine extends kernel.process {
       return
     }
 
-    const haulers = new qlib.Cluster('haulers_' + source.id, this.room)
+    const haulers = this.getCluster(`haulers_${source.id}`, this.room)
     let distance = 50
     if (this.mine.name === this.room.name) {
       haulers.sizeCluster('hauler', 1)
@@ -183,7 +183,7 @@ class CityMine extends kernel.process {
   scout () {
     const center = new RoomPosition(25, 25, this.data.mine)
     const quantity = Game.rooms[this.data.mine] ? 0 : 1
-    const scouts = new qlib.Cluster('scout_' + this.data.mine, this.room)
+    const scouts = this.getCluster(`scout`, this.room)
     scouts.sizeCluster('spook', quantity)
     scouts.forEach(function (scout) {
       if (scout.room.name === center.roomName) {
@@ -203,7 +203,7 @@ class CityMine extends kernel.process {
       quantity = Math.min(this.room.getRoomSetting('RESERVER_COUNT'), controller.pos.getSteppableAdjacent().length)
     }
 
-    const reservists = new qlib.Cluster('reservists_' + this.mine.name, this.room)
+    const reservists = this.getCluster(`reservists`, this.room)
     reservists.sizeCluster('reservist', quantity)
     reservists.forEach(function (reservist) {
       if (!reservist.pos.isNearTo(controller)) {

--- a/src/programs/empire/expand.js
+++ b/src/programs/empire/expand.js
@@ -179,7 +179,7 @@ class EmpireExpand extends kernel.process {
     const closestCity = this.getClosestCity(this.data.colony)
     const center = new RoomPosition(25, 25, this.data.colony)
     const quantity = Game.rooms[this.data.colony] ? 0 : 1
-    const scouts = new qlib.Cluster('scout_' + this.data.colony, closestCity)
+    const scouts = this.getCluster(`scout`, closestCity)
     if (!Game.rooms[this.data.colony]) {
       scouts.sizeCluster('spook', quantity)
     }
@@ -199,7 +199,7 @@ class EmpireExpand extends kernel.process {
       return
     }
     const closestCity = this.getClosestCity(this.data.colony)
-    const claimer = new qlib.Cluster('claimers_' + this.data.colony, closestCity)
+    const claimer = this.getCluster(`claimers`, closestCity)
 
     // Give up 1000 ticks after launching the last claimer and move on to the next candidate room.
 
@@ -242,7 +242,7 @@ class EmpireExpand extends kernel.process {
       }
     }
 
-    const miners = new qlib.Cluster('miner_' + source.id, spawnRoom)
+    const miners = this.getCluster(`miner_${source.id}`, spawnRoom)
     if (!this.data.deathwatch) {
       miners.sizeCluster('miner', 1)
     }
@@ -269,7 +269,7 @@ class EmpireExpand extends kernel.process {
   build () {
     const controller = this.colony.controller
     const closestCity = this.getClosestCity(this.data.colony)
-    const builders = new qlib.Cluster('builers_' + this.data.colony, closestCity)
+    const builders = this.getCluster(`builders`, closestCity)
     const constructionSites = this.colony.find(FIND_MY_CONSTRUCTION_SITES)
     const site = constructionSites.length > 0 ? constructionSites[0] : false
     const hostileSpawns = this.hostileSpawns
@@ -339,7 +339,7 @@ class EmpireExpand extends kernel.process {
   upgrade () {
     const controller = this.colony.controller
     const closestCity = this.getClosestCity(this.data.colony)
-    const upgraders = new qlib.Cluster('upgraders_' + this.data.colony, closestCity)
+    const upgraders = this.getCluster(`upgraders`, closestCity)
     if (!this.data.deathwatch) {
       upgraders.sizeCluster('upgrader', 2)
     }

--- a/src/qos/process.js
+++ b/src/qos/process.js
@@ -84,6 +84,10 @@ class Process {
     }
   }
 
+  getCluster (name, room) {
+    return new qlib.Cluster(`${name}_${this.pid}`, room)
+  }
+
   period (interval, label = 'default') {
     if (!this.data.period) {
       this.data.period = {}


### PR DESCRIPTION
Clusters need unique names, so this PR adds a helper function to `Process` which takes a label (that does *not* need to be universally unique, just unique for the specific process) and combines the label with the process PID.