### PR TITLE
Fixed value for `REMOTE_MINES` setting in `roomLevelOptions`.

### DIFF
--- a/src/extends/room/control.js
+++ b/src/extends/room/control.js
@@ -16,7 +16,7 @@ let roomLevelOptions = {
     'DEDICATED_MINERS': true,
     'PURE_CARRY_FILLERS': true,
     'RESERVER_COUNT': 3,
-    'REMOTE_MINES': true,
+    'REMOTE_MINES': 2,
     'EXPAND_FROM': true
   },
   5: {},

--- a/src/extends/room/control.js
+++ b/src/extends/room/control.js
@@ -26,8 +26,7 @@ let roomLevelOptions = {
     'RESERVER_COUNT': 2
   },
   7: {
-    'RESERVER_COUNT': 1,
-    'REMOTE_MINES': 2
+    'RESERVER_COUNT': 1
   },
   8: {
     'UPGRADERS_QUANTITY': 1,


### PR DESCRIPTION
Correct me if i'm wrong, but this seemed off while reading through the code. My understanding is, that 'true' would translate into '1', which means the remote mines setting is not going to '2' until controller level 7.