### PR TITLE
Ignore 'hostile' creeps when they can't do harm.

### DIFF
--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -46,7 +46,7 @@ class CityDefense extends kernel.process {
       this.launchCreepProcess('loader', 'replenisher', this.data.room, 1)
     }
 
-    const playerHostiles = hostiles.filter(c => c.owner.username !== 'Invader' && c.isPotentialHazard())
+    const playerHostiles = hostiles.filter(c => c.owner.username !== 'Invader' && this.isPotentialHazard(c))
 
     if (playerHostiles.length > 0) {
       Logger.log(`Hostile creep owned by ${playerHostiles[0].owner.username} detected in room ${this.data.room}.`, LOG_WARN)
@@ -128,10 +128,15 @@ class CityDefense extends kernel.process {
   }
 
   isPotentialHazard (hostile) {
-    return hostile.getActiveBodyparts(ATTACK) > 0 ||
-    hostile.getActiveBodyparts(RANGED_ATTACK) > 0 ||
-    hostile.getActiveBodyparts(HEAL) > 0 ||
-    hostile.getActiveBodyparts(WORK) > 0
+    const hazardTypes = [ATTACK, RANGED_ATTACK, HEAL, WORK]
+
+    hostile.body.forEach(function (bodyPart) {
+      if (hazardTypes.includes(bodyPart.type) && bodyPart.hits > 0) {
+        return true
+      }
+    })
+
+    return false
   }
 }
 

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -128,7 +128,7 @@ class CityDefense extends kernel.process {
   }
 
   isPotentialHazard (hostile) {
-  	const hazardTypes = ['ATTACK', 'RANGED_ATTACK', 'HEAL', 'WORK']
+  	const hazardTypes = [ATTACK, RANGED_ATTACK, HEAL, WORK]
     
     return _.some(hostile.body, b => _.include(hazardTypes, b.type))
   }

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -128,15 +128,10 @@ class CityDefense extends kernel.process {
   }
 
   isPotentialHazard (hostile) {
-    const hazardTypes = [ATTACK, RANGED_ATTACK, HEAL, WORK]
-
-    hostile.body.forEach(function (bodyPart) {
-      if (bodyPart.hits > 0 && hazardTypes.includes(bodyPart.type)) {
-        return true
-      }
-    })
-
-    return false
+    return hostile.getActiveBodyparts(ATTACK) > 0 ||
+    hostile.getActiveBodyparts(RANGED_ATTACK) > 0 ||
+    hostile.getActiveBodyparts(HEAL) > 0 ||
+    hostile.getActiveBodyparts(WORK) > 0
   }
 }
 

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -128,7 +128,7 @@ class CityDefense extends kernel.process {
   }
 
   isPotentialHazard (hostile) {
-    const hazardTypes = [ATTACK, RANGED_ATTACK, HEAL, WORK]
+    const hazardTypes = [ATTACK, RANGED_ATTACK, HEAL, WORK, CLAIM]
     return _.some(hostile.body, b => _.include(hazardTypes, b.type))
   }
 }

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -128,10 +128,9 @@ class CityDefense extends kernel.process {
   }
 
   isPotentialHazard (hostile) {
-    return hostile.getActiveBodyparts(ATTACK) > 0 ||
-    hostile.getActiveBodyparts(RANGED_ATTACK) > 0 ||
-    hostile.getActiveBodyparts(HEAL) > 0 ||
-    hostile.getActiveBodyparts(WORK) > 0
+  	const hazardTypes = ['ATTACK', 'RANGED_ATTACK', 'HEAL', 'WORK']
+    
+    return _.some(hostile.body, b => _.include(hazardTypes, b.type))
   }
 }
 

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -128,8 +128,7 @@ class CityDefense extends kernel.process {
   }
 
   isPotentialHazard (hostile) {
-  	const hazardTypes = [ATTACK, RANGED_ATTACK, HEAL, WORK]
-    
+    const hazardTypes = [ATTACK, RANGED_ATTACK, HEAL, WORK]
     return _.some(hostile.body, b => _.include(hazardTypes, b.type))
   }
 }

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -131,7 +131,7 @@ class CityDefense extends kernel.process {
     const hazardTypes = [ATTACK, RANGED_ATTACK, HEAL, WORK]
 
     hostile.body.forEach(function (bodyPart) {
-      if (hazardTypes.includes(bodyPart.type) && bodyPart.hits > 0) {
+      if (bodyPart.hits > 0 && hazardTypes.includes(bodyPart.type)) {
         return true
       }
     })

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -46,7 +46,8 @@ class CityDefense extends kernel.process {
       this.launchCreepProcess('loader', 'replenisher', this.data.room, 1)
     }
 
-    const playerHostiles = hostiles.filter(c => c.owner.username !== 'Invader')
+    const playerHostiles = hostiles.filter(c => c.owner.username !== 'Invader' && c.isPotentialHazard())
+
     if (playerHostiles.length > 0) {
       Logger.log(`Hostile creep owned by ${playerHostiles[0].owner.username} detected in room ${this.data.room}.`, LOG_WARN)
       this.safeMode(playerHostiles)
@@ -124,6 +125,13 @@ class CityDefense extends kernel.process {
       }
     }
     return false
+  }
+
+  isPotentialHazard (hostile) {
+    return hostile.getActiveBodyparts(ATTACK) > 0 ||
+    hostile.getActiveBodyparts(RANGED_ATTACK) > 0 ||
+    hostile.getActiveBodyparts(HEAL) > 0 ||
+    hostile.getActiveBodyparts(WORK) > 0
   }
 }
 


### PR DESCRIPTION
Motivation: After a scout comes in, safemode is triggered unnecessary, i think it would be better if this only happens when something comes close that could potentially do damage. The filter only applies to the 'safeMode' mechanism for now.