### PR TITLE
Fix for errors when building remote container.

### DIFF
--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -110,7 +110,12 @@ class CityMine extends kernel.process {
     } else if (this.room.terminal) {
       storage = this.room.terminal
     } else if (this.remote) {
+      if(!this.room.structure){
+        return
+      }
+      
       const containers = this.room.structure[STRUCTURE_CONTAINER]
+      
       if (containers && containers.length > 0) {
         if (containers.length > 1) {
           containers.sort((a, b) => a.store[RESOURCE_ENERGY] - b.store[RESOURCE_ENERGY])

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -110,12 +110,12 @@ class CityMine extends kernel.process {
     } else if (this.room.terminal) {
       storage = this.room.terminal
     } else if (this.remote) {
-      if(!this.room.structure){
+      if (!this.room.structure) {
         return
       }
-      
+
       const containers = this.room.structure[STRUCTURE_CONTAINER]
-      
+
       if (containers && containers.length > 0) {
         if (containers.length > 1) {
           containers.sort((a, b) => a.store[RESOURCE_ENERGY] - b.store[RESOURCE_ENERGY])

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -110,11 +110,7 @@ class CityMine extends kernel.process {
     } else if (this.room.terminal) {
       storage = this.room.terminal
     } else if (this.remote) {
-      if (!this.room.structure) {
-        return
-      }
-
-      const containers = this.room.structure[STRUCTURE_CONTAINER]
+      const containers = this.room.structures[STRUCTURE_CONTAINER]
 
       if (containers && containers.length > 0) {
         if (containers.length > 1) {
@@ -122,7 +118,7 @@ class CityMine extends kernel.process {
         }
         storage = containers[0]
       } else {
-        const spawns = this.room.structure[STRUCTURE_SPAWN]
+        const spawns = this.room.structures[STRUCTURE_SPAWN]
         if (spawns) {
           if (spawns.length > 1) {
             spawns.sort((a, b) => a.energy - b.energy)


### PR DESCRIPTION
When the (first ?) remote container is build, it would throw exceptions due to an empty structures object. Not sure if this is the desired solution, but it does solve it.