### PR TITLE
Raise delayoverride to five

### DIFF
--- a/.gitconsensus.yaml
+++ b/.gitconsensus.yaml
@@ -14,7 +14,7 @@ threshold: 0.74
 mergedelay: 6
 
 # Number of votes at which the mergedelay gets ignored, assuming no negative votes.
-delayoverride: 4
+delayoverride: 5
 
 # Number of hours after last action (commit or opening the pull request) before issue is autoclosed
 timeout: 168


### PR DESCRIPTION
Now that we have more contributors raising this will prevent overly quick merges.