### PR TITLE
Fix for cache cleankey errors.

### DIFF
--- a/src/thirdparty/sos_lib_cache.js
+++ b/src/thirdparty/sos_lib_cache.js
@@ -175,10 +175,10 @@ cache.__cleankey = function (object, key) {
     for(var label in object[key]) {
       if(object[key][label]) {
         if(object[key][label].tick) {
-          if(object[key][label].exp && object[key][label].exp < Game.time) {
+          if(object[key][label] && object[key][label].exp && object[key][label].exp < Game.time) {
             delete object[key][label]
           }
-          if(object[key][label].lu && object[key][label].lu < Game.time) {
+          if(object[key][label] && object[key][label].lu && object[key][label].lu < Game.time) {
             delete object[key][label]
           }
         } else {


### PR DESCRIPTION
Cache cleankey throws `undefined` error after deleting it in the first `if` statement.
Added extra condition, so it won't throw error's due to non-existance after intentionally deleting it.