### PR TITLE
Use of PUBLIC_ACCOUNT to trigger behavior

### DIFF
--- a/src/lib/genome.js
+++ b/src/lib/genome.js
@@ -26,13 +26,11 @@
  * myGenome.trait('aggression', 5, {min: 1, max: 9})
  */
 class Genome {
-  constructor (initializer) {
+  constructor (initializer, returnExpected = false) {
     // defined for convenience, do not change without also changing Lehmer multiplier in `_getNumberFromSeed`
     this.max = 2147483647
     this.seed = this._getNumberFromString(initializer)
-    if (initializer === 'Quorum') {
-      this.returnDefault = true
-    }
+    this.returnDefault = returnExpected
   }
 
   trait (name, expected, opts) {
@@ -173,9 +171,6 @@ if (typeof module !== 'undefined' && !module.parent) {
   }
 } else {
   // Use the botname as the seed.
-  let botname = 'Quorum'
-  if (global.USERNAME) {
-    botname = global.USERNAME
-  }
-  module.exports = new Genome(botname)
+  let botname = global.USERNAME ? global.USERNAME : 'Quorum'
+  module.exports = new Genome(botname, PUBLIC_ACCOUNT)
 }

--- a/src/roles/spook.js
+++ b/src/roles/spook.js
@@ -1,7 +1,12 @@
 'use strict'
 
 const MetaRole = require('roles_meta')
-const CONTROLLER_MESSAGE = '* Self Managed Code * quorum.tedivm.com * #quorum in Slack *'
+let CONTROLLER_MESSAGE
+if (PUBLIC_ACCOUNT) {
+  CONTROLLER_MESSAGE = 'Self Managed Code * quorum.tedivm.com * github.com/ScreepsQuorum/screeps-quorum * #quorum in Slack'
+} else {
+  CONTROLLER_MESSAGE = 'Fully Autonomous Open Source Bot * github.com/ScreepsQuorum/screeps-quorum * #quorum in Slack'
+}
 
 class Spook extends MetaRole {
   getBuild (room, options) {
@@ -70,7 +75,7 @@ class Spook extends MetaRole {
     if (!creep.room.controller) {
       return false
     }
-    if (creep.room.controller.sign && creep.room.controller.sign.text === CONTROLLER_MESSAGE) {
+    if (creep.room.controller.sign && creep.room.controller.sign.username === USERNAME) {
       return false
     }
     if (creep.pos.isNearTo(creep.room.controller)) {


### PR DESCRIPTION
* Have different controller messages for the public account than others.

* Have the `PUBLIC_ACCOUNT` value trigger the genome library’s `expected` results mode.