### PR TITLE
Low level room improvements

### DIFF
--- a/src/extends/creep/actions.js
+++ b/src/extends/creep/actions.js
@@ -28,6 +28,39 @@ Creep.prototype.recharge = function () {
     return true
   }
 
+  // Check for qualifying dropped energy.
+  const resources = this.room.find(FIND_DROPPED_RESOURCES, {filter: function (resource) {
+    if (resource.resourceType !== RESOURCE_ENERGY) {
+      return false
+    }
+
+    // Is resource on top of container?
+    const structures = resource.pos.lookFor(LOOK_STRUCTURES)
+    for (let structure of structures) {
+      if (structure.structureType === STRUCTURE_CONTAINER) {
+        return true
+      }
+    }
+
+    // Is the resource near the room storage?
+    if (this.room.storage && this.room.storage.pos.getRangeTo(resource) <= 2) {
+      return true
+    }
+
+    return false
+  }})
+
+  if (resources.length > 0) {
+    const resource = this.pos.findClosestByRange(resources)
+    if (!this.pos.isNearTo(resource)) {
+      this.travelTo(resource)
+    }
+    if (this.pos.isNearTo(resource)) {
+      this.pickup(resource)
+    }
+    return true
+  }
+
   // If there is no storage check for containers.
   const containers = _.filter(this.room.structures[STRUCTURE_CONTAINER], (a) => a.store[RESOURCE_ENERGY] > 200)
   if (containers.length > 0) {

--- a/src/extends/creep/actions.js
+++ b/src/extends/creep/actions.js
@@ -5,7 +5,7 @@ Creep.prototype.recharge = function () {
     this.memory.recharge = true
   }
   if (this.carry[RESOURCE_ENERGY] >= this.carryCapacity) {
-    this.memory.recharge = false
+    delete this.memory.recharge
   }
   if (!this.memory.recharge) {
     return false

--- a/src/extends/creep/actions.js
+++ b/src/extends/creep/actions.js
@@ -43,7 +43,7 @@ Creep.prototype.recharge = function () {
     }
 
     // Is the resource near the room storage?
-    if (this.room.storage && this.room.storage.pos.getRangeTo(resource) <= 2) {
+    if (resource.room.storage && resource.room.storage.pos.getRangeTo(resource) <= 2) {
       return true
     }
 

--- a/src/extends/room/control.js
+++ b/src/extends/room/control.js
@@ -9,12 +9,14 @@ let roomLevelOptions = {
   },
   2: {},
   3: {
+    'PURE_CARRY_FILLERS': true,
+    'ADDITIONAL_FILLERS': true,
     'SELF_SUFFICIENT': true,
     'REMOTE_MINES': 1
   },
   4: {
     'DEDICATED_MINERS': true,
-    'PURE_CARRY_FILLERS': true,
+    'ADDITIONAL_FILLERS': false,
     'RESERVER_COUNT': 3,
     'REMOTE_MINES': 2,
     'EXPAND_FROM': true

--- a/src/extends/room/meta.js
+++ b/src/extends/room/meta.js
@@ -21,6 +21,9 @@ const quadrantMap = {
 }
 
 Room.serializeName = function (name) {
+  if (name === 'sim') {
+    return 'sim'
+  }
   const coords = Room.getCoordinates(name)
   let quad
   if (coords.x_dir === 'E') {
@@ -34,6 +37,9 @@ Room.serializeName = function (name) {
 }
 
 Room.deserializeName = function (sName) {
+  if (sName === 'sim') {
+    return 'sim'
+  }
   const xDir = quadrantMap[sName[0]].x
   const yDir = quadrantMap[sName[0]].y
   const x = sName.codePointAt(1) - unicodeModifier
@@ -105,6 +111,9 @@ Room.getManhattanDistance = function (startRoomName, endRoomName) {
 }
 
 Room.isSourcekeeper = function (name) {
+  if (name === 'sim') {
+    return true
+  }
   const coords = Room.getCoordinates(name)
   let xMod = coords.x % 10
   let yMod = coords.y % 10

--- a/src/extends/room/meta.js
+++ b/src/extends/room/meta.js
@@ -59,6 +59,9 @@ Room.getCoordinates = function (name) {
 }
 
 Room.getRoomsInRange = function (name, range) {
+  if (name === 'sim') {
+    return []
+  }
   const coords = Room.getCoordinates(name)
   const startXdir = coords.x_dir
   const startYdir = coords.y_dir
@@ -121,6 +124,9 @@ Room.isSourcekeeper = function (name) {
 }
 
 Room.isHallway = function (name) {
+  if (name === 'sim') {
+    return false
+  }
   const coords = Room.getCoordinates(name)
   let xMod = coords.x % 10
   let yMod = coords.y % 10

--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -41,9 +41,10 @@ class City extends kernel.process {
     let options = {}
     if (this.room.getRoomSetting('PURE_CARRY_FILLERS')) {
       options['carry_only'] = true
-      options['energy'] = 1600
+      options['energy'] = Math.max(Math.min(1600, this.room.energyCapacityAvailable / 2), 400)
     }
-    this.launchCreepProcess('fillers', 'filler', this.data.room, 2, options)
+    const fillerQuantity = this.room.getRoomSetting('ADDITIONAL_FILLERS') ? 4 : 2
+    this.launchCreepProcess('fillers', 'filler', this.data.room, fillerQuantity, options)
 
     // Launch mining
     if (this.room.energyCapacityAvailable >= 800) {

--- a/src/programs/empire/intel.js
+++ b/src/programs/empire/intel.js
@@ -48,6 +48,9 @@ class EmpireIntel extends kernel.process {
   }
 
   cleanTargets () {
+    if (!Memory.intel) {
+      return
+    }
     const targets = Object.keys(Memory.intel.targets)
     for (let target of targets) {
       if (Game.time - Memory.intel.targets[target] > 5000) {


### PR DESCRIPTION
* Fixes for simulations.

* Have the `recharge` function pick up from dropped resources.

* Go to "pure carry" creeps at PRL3, increasing the capacity but relying on miners for energy.

* Reduce the size of pure carry fillers so they spawn quicker and the spawners don't starve from lack of energy.
