### PR TITLE
Allow the username field in .screeps.json

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,7 +53,7 @@ gulp.task('deploy', ['copy'], () => {
 
   options.ptr = opts.ptr || false
   options.branch = opts.branch || 'default'
-  options.email = opts.email
+  options.email = opts.email || opts.username
   options.password = opts.password
   options.host = opts.host || 'screeps.com'
   options.secure = !!opts.ssl || (options.host === 'screeps.com')


### PR DESCRIPTION
Many people don't realize that the field is named `email` rather than `username` in .screeps.json, this allows a `username` field for those like me who want the field name to match what the contents actually are ;)