### PR TITLE
Better deal with rooms that are flooding with energy

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
       "PathCache",
       "SCRIPT_VERSION",
       "sos",
+      "ECONOMY_BURSTING",
       "ECONOMY_CRASHED",
       "ECONOMY_DEVELOPING",
       "ECONOMY_STABLE",

--- a/src/extends/room/control.js
+++ b/src/extends/room/control.js
@@ -19,13 +19,14 @@ let roomLevelOptions = {
     'ADDITIONAL_FILLERS': false,
     'RESERVER_COUNT': 3,
     'REMOTE_MINES': 2,
-    'EXPAND_FROM': true
+    'EXPAND_FROM': true,
+    'ALLOW_MINING_SCALEBACK': true
   },
   5: {},
   6: {
     'EXTRACT_MINERALS': true,
-    'UPGRADERS_QUANTITY': 3,
-    'RESERVER_COUNT': 2
+    'RESERVER_COUNT': 2,
+    'ALLOW_MINING_SCALEBACK': false
   },
   7: {
     'RESERVER_COUNT': 1

--- a/src/extends/room/control.js
+++ b/src/extends/room/control.js
@@ -25,11 +25,11 @@ let roomLevelOptions = {
   5: {},
   6: {
     'EXTRACT_MINERALS': true,
-    'RESERVER_COUNT': 2,
-    'ALLOW_MINING_SCALEBACK': false
+    'RESERVER_COUNT': 2
   },
   7: {
-    'RESERVER_COUNT': 1
+    'RESERVER_COUNT': 1,
+    'ALLOW_MINING_SCALEBACK': false
   },
   8: {
     'UPGRADERS_QUANTITY': 1,

--- a/src/extends/room/economy.js
+++ b/src/extends/room/economy.js
@@ -4,13 +4,15 @@ global.ECONOMY_CRASHED = 0
 global.ECONOMY_DEVELOPING = 1
 global.ECONOMY_STABLE = 2
 global.ECONOMY_SURPLUS = 3
+global.ECONOMY_BURSTING = 4
 
 const economySettings = {
   'EXPAND_FROM': ECONOMY_DEVELOPING,
   'BUILD_STRUCTURES': ECONOMY_STABLE,
   'UPGRADE_CONTROLLERS': ECONOMY_STABLE,
   'EXTRACT_MINERALS': ECONOMY_STABLE,
-  'EXTRA_UPGRADERS': ECONOMY_SURPLUS
+  'EXTRA_UPGRADERS': ECONOMY_SURPLUS,
+  'MORE_EXTRA_UPGRADERS': ECONOMY_BURSTING
 }
 
 Room.prototype.isEconomyCapable = function (key) {
@@ -40,6 +42,11 @@ Room.prototype.getEconomyLevel = function () {
   // When fully developed between 300000 and 320000
   if (energy < (desiredBuffer + 20000)) {
     return ECONOMY_STABLE
+  }
+
+  // Need to ditch energy as we have way too much in storage
+  if (_.sum(this.storage.storage) > this.storage.storeCapacity * 0.9) {
+    return ECONOMY_BURSTING
   }
 
   // When fully developed over 300000

--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -95,6 +95,9 @@ class City extends kernel.process {
       if (this.room.isEconomyCapable('EXTRA_UPGRADERS')) {
         upgraderQuantity += 2
       }
+      if (this.room.isEconomyCapable('MORE_EXTRA_UPGRADERS')) {
+        upgraderQuantity += 2
+      }
       if (this.room.controller.level >= 8) {
         upgraderQuantity = 1
       }

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -40,6 +40,9 @@ class CityMine extends kernel.process {
       this.mine = Game.rooms[this.data.mine]
       this.underAttack = this.mine.find(FIND_HOSTILE_CREEPS).length > 0
       this.reserveRoom()
+      if (this.room.getEconomyLevel() >= ECONOMY_BURSTING) {
+        this.strictSpawning = this.room.getRoomSetting('ALLOW_MINING_SCALEBACK')
+      }
     } else {
       this.mine = this.room
     }
@@ -79,7 +82,7 @@ class CityMine extends kernel.process {
     if (miners.getClusterSize() === 1 && minerCreeps.length > 0 && minerCreeps[0].ticksToLive < 60) {
       minerQuantity = 2
     }
-    if (this.underAttack) {
+    if (this.underAttack || this.strictSpawning) {
       minerQuantity = 0
     }
 
@@ -134,9 +137,9 @@ class CityMine extends kernel.process {
 
     const haulers = this.getCluster(`haulers_${source.id}`, this.room)
     let distance = 50
-    if (!this.underAttack && this.mine.name === this.room.name) {
+    if (!this.underAttack && !this.strictSpawning && this.mine.name === this.room.name) {
       haulers.sizeCluster('hauler', 1)
-    } else if (!this.underAttack) {
+    } else if (!this.underAttack && !this.strictSpawning) {
       if (!this.data.ssp) {
         this.data.ssp = {}
       }


### PR DESCRIPTION
* Add new economy level (`ECONOMY_BURSTING`) that triggers under the same conditions as `ECONOMY_SURPLUS` and the room storage is over 90% capacity.

* Add additional upgraders when `ECONOMY_BURSTING` (this stacks with the addition given during `ECONOMY_SURPLUS`.

* When `ECONOMY_BURSTING` and `ALLOW_MINING_SCALEBACK` is true (set by room control) remote mining operations will stop spawning miners and haulers to give up their spawn space to the upgraders.