### PR TITLE
Fix construction at PRL8

### DIFF
--- a/src/extends/room/construction.js
+++ b/src/extends/room/construction.js
@@ -120,6 +120,9 @@ Room.prototype.getNextMissingStructureType = function () {
   const structureCount = this.getStructureCount(FIND_STRUCTURES)
   const constructionCount = this.getConstructionCount()
   const nextLevel = this.getPracticalRoomLevel() + 1
+  if (!LEVEL_BREAKDOWN[nextLevel]) {
+    return false
+  }
   const nextLevelStructureCount = LEVEL_BREAKDOWN[nextLevel]
   const structures = Object.keys(nextLevelStructureCount)
 


### PR DESCRIPTION
Since there is no PRL9 the check for structures at that level was throwing an error.