### PR TITLE
Rebuild destroyed rooms using neighbors

### DIFF
--- a/src/extends/room/territory.js
+++ b/src/extends/room/territory.js
@@ -25,6 +25,14 @@ Room.addCity = function (roomName) {
   }
 }
 
+Room.removeCity = function (roomName) {
+  if (Memory.territory && Memory.territory[roomName]) {
+    delete Memory.territory[roomName]
+    Logger.log(`Removing city ${roomName}`)
+    qlib.notify.send(`Removing city ${roomName} from empire`)
+  }
+}
+
 Room.isCity = function (roomName) {
   return Boolean(Memory.territory[roomName])
 }

--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -11,10 +11,20 @@ class City extends kernel.process {
   }
 
   main () {
-    if (!Game.rooms[this.data.room]) {
+    if (!Game.rooms[this.data.room] || !Game.rooms[this.data.room].controller.my) {
+      Room.removeCity(this.data.room)
       return this.suicide()
     }
     this.room = Game.rooms[this.data.room]
+
+    const spawns = this.room.find(FIND_MY_SPAWNS)
+    if (spawns.length < 0) {
+      this.launchChildProcess('gethelp', 'empire_expand', {
+        'colony': this.data.room,
+        'recover': true
+      })
+      return
+    }
 
     this.launchChildProcess('spawns', 'spawns', {
       'room': this.data.room

--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -18,7 +18,7 @@ class City extends kernel.process {
     this.room = Game.rooms[this.data.room]
 
     const spawns = this.room.find(FIND_MY_SPAWNS)
-    if (spawns.length < 0) {
+    if (spawns.length <= 0) {
       this.launchChildProcess('gethelp', 'empire_expand', {
         'colony': this.data.room,
         'recover': true

--- a/src/programs/empire/expand.js
+++ b/src/programs/empire/expand.js
@@ -380,7 +380,7 @@ class EmpireExpand extends kernel.process {
     const closestCity = this.getClosestCity(this.data.colony)
     const upgraders = this.getCluster(`upgraders`, closestCity)
     if (!this.data.deathwatch) {
-      upgraders.sizeCluster('upgrader', 2)
+      upgraders.sizeCluster('upgrader', this.data.recover ? 1 : 2)
     }
     upgraders.forEach(function (upgrader) {
       if (upgrader.room.name !== controller.room.name) {

--- a/src/programs/empire/expand.js
+++ b/src/programs/empire/expand.js
@@ -27,7 +27,9 @@ class EmpireExpand extends kernel.process {
       }
       return
     }
-
+    if (!this.getClosestCity(this.data.colony)) {
+      return
+    }
     if (!this.data.recover) {
       this.scout()
     }
@@ -174,13 +176,16 @@ class EmpireExpand extends kernel.process {
       if (!Game.rooms[city]) {
         continue
       }
+      if (!Game.rooms[city].getRoomSetting('EXPAND_FROM')) {
+        continue
+      }
       const testDistance = Room.getManhattanDistance(city, roomName)
       if (distance > testDistance) {
         closest = city
         distance = testDistance
       }
     }
-    return Game.rooms[closest]
+    return closest ? Game.rooms[closest] : false
   }
 
   getCandidateList () {


### PR DESCRIPTION
This adds a new `recover` mode to the `expand` program which operates in a more limited way (as the room is already claimed and running its own programs), sending out upgraders and builders to the room in order to get it rebuilt.

It also better handles failed cities (which have completely timed out) by removing them from the `city` list.