### PR TITLE
Added cachedStructure check to filler role

### DIFF
--- a/src/roles/filler.js
+++ b/src/roles/filler.js
@@ -29,7 +29,7 @@ class Filler extends MetaRole {
     // Check to see if creep is already assigned a valid target and reuse.
     if (creep.memory.ft) {
       const cachedStructure = Game.getObjectById(creep.memory.ft)
-      if (cachedStructure.energy < cachedStructure.energyCapacity) {
+      if (cachedStructure && cachedStructure.energy < cachedStructure.energyCapacity) {
         this.fillStructure(creep, cachedStructure)
         return
       } else {


### PR DESCRIPTION
Fixes the following error:
```
TypeError: Cannot read property 'energy' of null
   at Replenisher.manageCreep (roles_filler:32:26)
   at ProgramCreep.main (programs_creep:36:10)
   at ProgramCreep.run (qos_process:147:10)
   at QosKernel.run (qos_kernel:84:24)
   at Object.module.exports.loop (main:63:10)
   at __module (__mainLoop:1:52)
   at __mainLoop:2:3
   at sigintHandlersWrap (vm.js:32:31)
   at sigintHandlersWrap (vm.js:73:12)
   at ContextifyScript.Script.runInContext (vm.js:31:12)
```