### PR TITLE
Clear spawn queue when practical room level changes

### DIFF
--- a/src/extends/room/spawning.js
+++ b/src/extends/room/spawning.js
@@ -24,6 +24,19 @@ Room.prototype.queueCreep = function (role, options = {}) {
   return name
 }
 
+Room.prototype.clearSpawnQueue = function () {
+  Room.clearSpawnQueue(this.name)
+}
+
+Room.clearSpawnQueue = function (roomname) {
+  if (!Memory.spawnqueue) {
+    return
+  }
+  if (Memory.spawnqueue[roomname]) {
+    delete Memory.spawnqueue[roomname]
+  }
+}
+
 Room.prototype.getQueuedCreep = function () {
   if (!Memory.spawnqueue) {
     return false

--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -17,6 +17,16 @@ class City extends kernel.process {
     }
     this.room = Game.rooms[this.data.room]
 
+    // Detect when room level changes and clear spawnqueue.
+    if (!this.data.prl) {
+      this.data.prl = this.room.getPracticalRoomLevel()
+    }
+    const roomLevel = this.room.getPracticalRoomLevel()
+    if (this.data.prl !== roomLevel) {
+      this.data.prl = roomLevel
+      this.room.clearSpawnQueue()
+    }
+
     const spawns = this.room.find(FIND_MY_SPAWNS)
     if (spawns.length <= 0) {
       this.launchChildProcess('gethelp', 'empire_expand', {


### PR DESCRIPTION
This way when a room is attacked and severely damaged it won’t attempt to spawn useless creeps that are no longer relevant.