### PR TITLE
Reduce upgraders on recovering rooms

### DIFF
--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -112,6 +112,10 @@ class City extends kernel.process {
     // Launch upgraders
     if (this.room.isEconomyCapable('UPGRADE_CONTROLLERS')) {
       let upgraderQuantity = this.room.getRoomSetting('UPGRADERS_QUANTITY')
+      // If the room is not done being built up reduce the upgraders.
+      if (this.room.controller.level > this.room.getPracticalRoomLevel()) {
+        upgraderQuantity = 0
+      }
       if (this.room.isEconomyCapable('EXTRA_UPGRADERS')) {
         upgraderQuantity += 2
       }

--- a/src/programs/empire/expand.js
+++ b/src/programs/empire/expand.js
@@ -377,7 +377,11 @@ class EmpireExpand extends kernel.process {
     const closestCity = this.getClosestCity(this.data.colony)
     const upgraders = this.getCluster(`upgraders`, closestCity)
     if (!this.data.deathwatch) {
-      upgraders.sizeCluster('upgrader', this.data.recover ? 1 : 2)
+      let quantity = 2
+      if (this.data.recover) {
+        quantity = this.colony.controller.isTimingOut() ? 1 : 0
+      }
+      upgraders.sizeCluster('upgrader', quantity)
     }
     upgraders.forEach(function (upgrader) {
       if (upgrader.room.name !== controller.room.name) {


### PR DESCRIPTION
Reduce upgraders if a room is being assisted from its neighbor or is building itself up from one level to another (as in, its current practical room level is lower than the room level itself). This way the energy in the room will be focused on building.

If the room is in danger of downgrading upgraders will still be sent in by the expansion program and spawned by the room’s emergency upgrader protocols.