### PR TITLE
Add restrictions to when a room will safemode

### DIFF
--- a/src/extends/controller.js
+++ b/src/extends/controller.js
@@ -5,3 +5,25 @@ StructureController.prototype.isTimingOut = function () {
   }
   return CONTROLLER_DOWNGRADE[this.level] - this.ticksToDowngrade > 4000
 }
+
+StructureController.prototype.canSafemode = function () {
+  if (!this.level) {
+    return false
+  }
+  if (!this.my) {
+    return false
+  }
+  if (!this.safeModeAvailable) {
+    return false
+  }
+  if (this.safeModeCooldown) {
+    return false
+  }
+  if (this.upgradeBlocked) {
+    return false
+  }
+  if (CONTROLLER_DOWNGRADE[this.level] - this.ticksToDowngrade >= 5000) {
+    return false
+  }
+  return true
+}

--- a/src/extends/controller.js
+++ b/src/extends/controller.js
@@ -22,7 +22,7 @@ StructureController.prototype.canSafemode = function () {
   if (this.upgradeBlocked) {
     return false
   }
-  if (CONTROLLER_DOWNGRADE[this.level] - this.ticksToDowngrade >= 5000) {
+  if (this.ticksToDowngrade && CONTROLLER_DOWNGRADE[this.level] - this.ticksToDowngrade >= 5000) {
     return false
   }
   return true

--- a/src/extends/room/control.js
+++ b/src/extends/room/control.js
@@ -29,7 +29,8 @@ let roomLevelOptions = {
   },
   7: {
     'RESERVER_COUNT': 1,
-    'ALLOW_MINING_SCALEBACK': false
+    'ALLOW_MINING_SCALEBACK': false,
+    'ALWAYS_SAFEMODE': true
   },
   8: {
     'UPGRADERS_QUANTITY': 1,

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -136,6 +136,34 @@ class CityDefense extends kernel.process {
     }
 
     let safeStructures = room.find(FIND_MY_SPAWNS)
+
+    // If there are no spawns this room isn't worth protecting with a safemode.
+    if (safeStructures.length <= 0) {
+      return false
+    }
+
+    // If other rooms are more important than this one save the safemode
+    if (!room.getRoomSetting('ALWAYS_SAFEMODE')) {
+      const cities = Room.getCities()
+      let highestLevel = 0
+      for (let cityName of cities) {
+        if (!Game.rooms[cityName]) {
+          continue
+        }
+        let city = Game.rooms[cityName]
+        if (city.getRoomSetting('ALWAYS_SAFEMODE')) {
+          return false
+        }
+        let level = city.getPracticalRoomLevel()
+        if (highestLevel < level) {
+          highestLevel = level
+        }
+      }
+      if (room.getPracticalRoomLevel() < highestLevel) {
+        return false
+      }
+    }
+
     safeStructures.push(room.controller)
     let structure
     for (structure of safeStructures) {

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -131,7 +131,7 @@ class CityDefense extends kernel.process {
     if (room.controller.safeMode && room.controller.safeMode > 0) {
       return true
     }
-    if (room.controller.safeModeAvailable <= 0 || room.controller.safeModeCooldown || room.controller.upgradeBlocked) {
+    if (!room.controller.canSafemode()) {
       return false
     }
 
@@ -151,6 +151,9 @@ class CityDefense extends kernel.process {
           continue
         }
         let city = Game.rooms[cityName]
+        if (!city.controller.canSafemode()) {
+          continue
+        }
         if (city.getRoomSetting('ALWAYS_SAFEMODE')) {
           return false
         }


### PR DESCRIPTION
This prevents the system from "wasting" safemodes. 

* If no spawns are available in the room it will not safemode.
* If the room control setting `ALWAYS_SAFEMODE` is true it will safemode, otherwise
* If the practical room level is greater than or equal to the highest PRL in the empire it will safemode.

This way only rooms that can help reboot the empire will be put into safemode.