### PR TITLE
Trigger territory check when there are no rooms claimed

### DIFF
--- a/src/extends/room/territory.js
+++ b/src/extends/room/territory.js
@@ -4,7 +4,7 @@
 
 Room.getCities = function () {
   // When respawning the first room has to be autodetected, after which new cities will need to added.
-  if (!Memory.territory) {
+  if (!Memory.territory || Object.keys(Memory.territory).length <= 0) {
     Memory.territory = {}
     for (let roomName of Object.keys(Game.rooms)) {
       const room = Game.rooms[roomName]


### PR DESCRIPTION
This is needed for the bug where clearing out memory doesn’t appear to work on non-active shards.