### PR TITLE
If room candidate list is empty refill it.

### DIFF
--- a/src/programs/empire/expand.js
+++ b/src/programs/empire/expand.js
@@ -132,7 +132,7 @@ class EmpireExpand extends kernel.process {
       return this.data.candidates.pop()
     }
 
-    if (typeof this.data.candidateList === 'undefined') {
+    if (typeof this.data.candidateList === 'undefined' || this.data.candidates.length <= 0) {
       this.data.candidateList = this.getCandidateList()
     }
     if (!this.data.candidateScores) {


### PR DESCRIPTION
When there is only a single room and the `expand` program runs it may define the `candidateList` as an empty array. This happens because the `expand` program launches immediately but there are no rooms capable of expanding until the first one hits `PRL4`.  This PR fixes this by checking for empty arrays and attempting to rebuild the list should they occur.