### PR TITLE
Remove debugging statement

### DIFF
--- a/src/programs/city/fortify.js
+++ b/src/programs/city/fortify.js
@@ -46,7 +46,6 @@ class CityFortify extends kernel.process {
 
     const target = this.getTarget()
     if (!target) {
-      Logger.highlightData(target)
       return
     }
 


### PR DESCRIPTION
Apparently the `highlights` break the screeps dashboard somehow.