### PR TITLE
Don't run `getTarget` if PRL has no defensive structures

### DIFF
--- a/src/programs/city/fortify.js
+++ b/src/programs/city/fortify.js
@@ -44,6 +44,10 @@ class CityFortify extends kernel.process {
       return
     }
 
+    if (!_.values(this.rampartLevels).some(a => a > 0)) {
+      return
+    }
+
     const target = this.getTarget()
     if (!target) {
       return


### PR DESCRIPTION
Currently if there are rampart levels defined the system will attempt to find a target, even if those rampart levels are all set to zero. Since there are no valid targets at that point it means there is nothing to cache so the function gets called every tick the program runs, forcing the program to process the relevant rampart maps.

This PR adds a check for that specific case, where the levels are defined but all set to zero, and stops the program before it goes into target selections.