### PR TITLE
Fix dynamic hauler sizing/count and apply it to in room mines

### DIFF
--- a/src/lib/cluster.js
+++ b/src/lib/cluster.js
@@ -54,6 +54,12 @@ class Cluster {
   }
 
   sizeCluster (role, quantity, options = {}, room = false) {
+    if (options.respawnAge) {
+      const creeps = this.getCreeps()
+      quantity += _.filter(creeps, function (creep) { return creep.ticksToLive <= options.respawnAge }).length
+      delete options.respawnAge
+    }
+
     if (this.memory.creeps.length >= quantity) {
       return true
     }

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -140,23 +140,20 @@ class CityMine extends kernel.process {
     }
 
     const haulers = this.getCluster(`haulers_${source.id}`, this.room)
-    let distance = 50
-    if (!this.underAttack && !this.strictSpawning && this.mine.name === this.room.name) {
-      haulers.sizeCluster('hauler', 1)
-    } else if (!this.underAttack && !this.strictSpawning) {
-      if (!this.data.ssp) {
-        this.data.ssp = {}
+    if (!this.data.ssp) {
+      this.data.ssp = {}
+    }
+    if (!this.data.ssp[source.id]) {
+      if (this.room.storage) {
+        this.data.ssp[source.id] = this.room.findPath(this.room.storage.pos, source.pos, {
+          ignoreCreeps: true,
+          maxOps: 6000
+        }).length
       }
-      if (!this.data.ssp[source.id]) {
-        if (this.room.storage) {
-          this.data.ssp[source.id] = this.room.findPath(this.room.storage, source, {
-            ignoreCreeps: true,
-            maxOps: 6000
-          }).length
-        }
-      }
-      distance = this.data.ssp[source.id] ? this.data.ssp[source.id] : 80
-      const carryAmount = (Math.ceil((distance * 20) / 100) * 100) + 200
+    }
+    const distance = this.data.ssp[source.id] ? this.data.ssp[source.id] * 1.3 : 80
+    if (!this.underAttack && !this.strictSpawning) {
+      const carryAmount = (Math.ceil((distance * 20) / 100) * 100)
       const carryCost = BODYPART_COST['move'] + BODYPART_COST['carry']
       const maxEnergy = carryCost * (MAX_CREEP_SIZE / 2)
       let energy = (carryAmount / CARRY_CAPACITY) * carryCost // 50 carry == 1m1c == 100 energy
@@ -165,7 +162,7 @@ class CityMine extends kernel.process {
         quantity = 2
         energy = maxEnergy
       }
-      haulers.sizeCluster('hauler', quantity, {'energy': maxEnergy})
+      haulers.sizeCluster('hauler', quantity, {'energy': energy})
     }
 
     haulers.forEach(function (hauler) {

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -153,7 +153,7 @@ class CityMine extends kernel.process {
     }
     const distance = this.data.ssp[source.id] ? this.data.ssp[source.id] : 80
     if (!this.underAttack && !this.strictSpawning) {
-      const carryAmount = (Math.ceil(((distance * 1.3) * 20) / 100) * 100)
+      const carryAmount = (Math.ceil(((distance * 1.4) * 20) / 100) * 100)
       const carryCost = BODYPART_COST['move'] + BODYPART_COST['carry']
       const maxEnergy = carryCost * (MAX_CREEP_SIZE / 2)
       let energy = (carryAmount / CARRY_CAPACITY) * carryCost // 50 carry == 1m1c == 100 energy

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -162,7 +162,10 @@ class CityMine extends kernel.process {
         quantity = 2
         energy = maxEnergy
       }
-      haulers.sizeCluster('hauler', quantity, {'energy': energy})
+
+      const respawnTime = ((energy / carryCost) * 2) * CREEP_SPAWN_TIME
+      const respawnAge = respawnTime + (distance * 1.2)
+      haulers.sizeCluster('hauler', quantity, {'energy': energy, 'respawnAge': respawnAge})
     }
 
     haulers.forEach(function (hauler) {

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -151,9 +151,9 @@ class CityMine extends kernel.process {
         }).length
       }
     }
-    const distance = this.data.ssp[source.id] ? this.data.ssp[source.id] * 1.3 : 80
+    const distance = this.data.ssp[source.id] ? this.data.ssp[source.id] : 80
     if (!this.underAttack && !this.strictSpawning) {
-      const carryAmount = (Math.ceil((distance * 20) / 100) * 100)
+      const carryAmount = (Math.ceil(((distance * 1.3) * 20) / 100) * 100)
       const carryCost = BODYPART_COST['move'] + BODYPART_COST['carry']
       const maxEnergy = carryCost * (MAX_CREEP_SIZE / 2)
       let energy = (carryAmount / CARRY_CAPACITY) * carryCost // 50 carry == 1m1c == 100 energy


### PR DESCRIPTION
When attempting to fix #216 I found a bug in our call to `findPath`- we apparently were not dynamically adjusting haulers even for remote rooms as the path that was returned had a length of zero.

Since it wasn't actually working before this PR adds in dynamic hauler sizes and quantity for the first time. As such it's really important people check the math here.

```javascript
const carryAmount = (Math.ceil(((distance * 1.4) * 20) / 100) * 100)
const carryCost = BODYPART_COST['move'] + BODYPART_COST['carry']
const maxEnergy = carryCost * (MAX_CREEP_SIZE / 2)
let energy = (carryAmount / CARRY_CAPACITY) * carryCost // 50 carry == 1m1c == 100 energy
let quantity = 1
if (energy > maxEnergy) {
  quantity = 2
  energy = maxEnergy
}
haulers.sizeCluster('hauler', quantity, {'energy': energy})
```

It also spawns the new haulers before the old haulers die to prevent periods where the creeps are not picking up energy.

resolves #216 