### PR TITLE
Added candidates check to EmpireExpand process

### DIFF
--- a/src/programs/empire/expand.js
+++ b/src/programs/empire/expand.js
@@ -135,7 +135,7 @@ class EmpireExpand extends kernel.process {
       return this.data.candidates.pop()
     }
 
-    if (typeof this.data.candidateList === 'undefined' || this.data.candidates.length <= 0) {
+    if (typeof this.data.candidateList === 'undefined' || !this.data.candidates || this.data.candidates.length <= 0) {
       this.data.candidateList = this.getCandidateList()
     }
     if (!this.data.candidateScores) {


### PR DESCRIPTION
Fixes the following error:
TypeError: Cannot read property 'length' of undefined
   at EmpireExpand.getNextCandidate (programs_empire_expand:138:79)
   at EmpireExpand.main (programs_empire_expand:22:30)
   at EmpireExpand.run (qos_process:147:10)
   at QosKernel.run (qos_kernel:84:24)
   at Object.module.exports.loop (main:64:10)
   at __module (__mainLoop:1:52)
   at __mainLoop:2:3
   at sigintHandlersWrap (vm.js:32:31)
   at sigintHandlersWrap (vm.js:73:12)
   at ContextifyScript.Script.runInContext (vm.js:31:12)