### PR TITLE
Maintain roads and containers using towers

### DIFF
--- a/src/programs/city.js
+++ b/src/programs/city.js
@@ -1,5 +1,12 @@
 'use strict'
 
+const roomPrograms = {
+  'spawns': 'spawns',
+  'defense': 'city_defense',
+  'reboot': 'city_reboot',
+  'works': 'city_publicworks'
+}
+
 class City extends kernel.process {
   constructor (...args) {
     super(...args)
@@ -46,15 +53,12 @@ class City extends kernel.process {
       return
     }
 
-    this.launchChildProcess('spawns', 'spawns', {
-      'room': this.data.room
-    })
-    this.launchChildProcess('defense', 'city_defense', {
-      'room': this.data.room
-    })
-    this.launchChildProcess('reboot', 'city_reboot', {
-      'room': this.data.room
-    })
+    // Launch children programs
+    for (const label in roomPrograms) {
+      this.launchChildProcess(label, roomPrograms[label], {
+        'room': this.data.room
+      })
+    }
 
     // If the room isn't planned launch the room layout program, otherwise launch construction program
     if (!this.room.getLayout().isPlanned()) {
@@ -152,7 +156,7 @@ class City extends kernel.process {
     }
 
     // Launch scouts to map out neighboring rooms
-    if (this.room.getRoomSetting('SCOUTS')) {
+    if (this.data.room !== 'sim' && this.room.getRoomSetting('SCOUTS')) {
       this.launchCreepProcess('scouts', 'spook', this.data.room, 1, {
         'priority': 4
       })

--- a/src/programs/city/construct.js
+++ b/src/programs/city/construct.js
@@ -4,9 +4,11 @@
  *
  */
 
-const ignoreStructures = [
+const ignoreConstructionSites = [
   STRUCTURE_RAMPART,
-  STRUCTURE_WALL
+  STRUCTURE_WALL,
+  STRUCTURE_CONTAINER,
+  STRUCTURE_ROAD
 ]
 
 class CityConstruct extends kernel.process {
@@ -26,7 +28,7 @@ class CityConstruct extends kernel.process {
     this.room = Game.rooms[this.data.room]
 
     const sites = this.room.find(FIND_MY_CONSTRUCTION_SITES, {'filter': function (structure) {
-      return !ignoreStructures.includes(structure)
+      return !ignoreConstructionSites.includes(structure)
     }})
     if (sites.length <= 0) {
       let result = this.room.constructNextMissingStructure()

--- a/src/programs/city/defense.js
+++ b/src/programs/city/defense.js
@@ -33,21 +33,7 @@ class CityDefense extends kernel.process {
     }
 
     const room = Game.rooms[this.data.room]
-
-    const towers = sos.lib.cache.getOrUpdate(
-        [this.data.room, 'towers'],
-        () => room.find(FIND_MY_STRUCTURES, {
-          filter: {
-            structureType: STRUCTURE_TOWER
-          }
-        })
-        .map(s => s.id), {
-          persist: true,
-          maxttl: 5000,
-          chance: 0.001
-        })
-      .map(id => Game.getObjectById(id))
-      .filter(t => t)
+    const towers = room.structures[STRUCTURE_TOWER]
 
     const hostiles = room.find(FIND_HOSTILE_CREEPS)
 

--- a/src/programs/city/publicworks.js
+++ b/src/programs/city/publicworks.js
@@ -48,11 +48,13 @@ class CityPublicWorks extends kernel.process {
     let lowestStructure = false
     for (const structureType of maintainStructures) {
       const structures = this.room.structures[structureType]
-      for (const structure of structures) {
-        const currentHealth = structure.hits / structure.hitsMax
-        if (currentHealth < lowestHealth) {
-          lowestHealth = currentHealth
-          lowestStructure = structure
+      if (structures) {
+        for (const structure of structures) {
+          const currentHealth = structure.hits / structure.hitsMax
+          if (currentHealth < lowestHealth) {
+            lowestHealth = currentHealth
+            lowestStructure = structure
+          }
         }
       }
     }

--- a/src/programs/city/publicworks.js
+++ b/src/programs/city/publicworks.js
@@ -59,7 +59,7 @@ class CityPublicWorks extends kernel.process {
       }
     }
     if (lowestHealth < healthThreshold && lowestStructure) {
-      _.shuffle(fullTowers)[0].repair(lowestStructure)
+      _.sample(fullTowers).repair(lowestStructure)
     }
   }
 }

--- a/src/programs/city/publicworks.js
+++ b/src/programs/city/publicworks.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const healthThreshold = 0.9
+const maintainStructures = [
+  STRUCTURE_ROAD,
+  STRUCTURE_CONTAINER
+]
+
+class CityPublicWorks extends kernel.process {
+  constructor (...args) {
+    super(...args)
+    this.priority = PRIORITIES_CONSTRUCTION
+  }
+
+  getDescriptor () {
+    return this.data.room
+  }
+
+  main () {
+    if (!Game.rooms[this.data.room]) {
+      return this.suicide()
+    }
+    this.room = Game.rooms[this.data.room]
+
+    const sites = this.room.find(FIND_MY_CONSTRUCTION_SITES, {'filter': function (structure) {
+      return maintainStructures.includes(structure)
+    }})
+    if (sites.length > 0 && this.room.isEconomyCapable('BUILD_STRUCTURES')) {
+      this.launchCreepProcess('builders', 'builder', this.data.room, 1)
+    }
+
+    this.towers()
+  }
+
+  towers () {
+    const towers = this.room.structures[STRUCTURE_TOWER]
+    if (!towers || towers.length <= 0) {
+      return
+    }
+    const fullTowers = _.filter(towers, tower => tower.energy > (TOWER_CAPACITY * 0.7))
+    if (fullTowers.length <= 0) {
+      return
+    }
+    if (this.room.find(FIND_HOSTILE_CREEPS).length > 0) {
+      return
+    }
+    let lowestHealth = 1
+    let lowestStructure = false
+    for (const structureType of maintainStructures) {
+      const structures = this.room.structures[structureType]
+      for (const structure of structures) {
+        const currentHealth = structure.hits / structure.hitsMax
+        if (currentHealth < lowestHealth) {
+          lowestHealth = currentHealth
+          lowestStructure = structure
+        }
+      }
+    }
+    if (lowestHealth < healthThreshold && lowestStructure) {
+      _.shuffle(fullTowers)[0].repair(lowestStructure)
+    }
+  }
+}
+
+module.exports = CityPublicWorks


### PR DESCRIPTION
* The structure with the lowest percentage of health will be selected,
* If the structure is above the repair threshold the program aborts,
* One tower with more than 70% energy is selected to repair the structure.

This also removes responsibility for spawning the builders for roads and containers away from the construction program, and reduces the number of builders for this task to one (from two).

resolves #201