### PR TITLE
Reduce upgraders at PRL6 to free up spawn space

### DIFF
--- a/src/extends/room/control.js
+++ b/src/extends/room/control.js
@@ -29,7 +29,8 @@ let roomLevelOptions = {
   5: {},
   6: {
     'EXTRACT_MINERALS': true,
-    'RESERVER_COUNT': 2
+    'RESERVER_COUNT': 2,
+    'UPGRADERS_QUANTITY': 3
   },
   7: {
     'RESERVER_COUNT': 1,


### PR DESCRIPTION
This reduces the number of upgraders to three at PRL6. In theory this should increase the amount being dumped into the controller, it'll just spread it out over more ticks and give the spawn a chance to spawn other things as well.