### PR TITLE
Have `getNextMissingStructureType` skip links

### DIFF
--- a/src/extends/room/construction.js
+++ b/src/extends/room/construction.js
@@ -145,7 +145,7 @@ Room.prototype.getNextMissingStructureType = function () {
   // Build all other structures.
   let structureType
   for (structureType of structures) {
-    if (this.getRoomSetting(`SKIP_STRUCTURE_${structureType}`)) {
+    if (structureType === STRUCTURE_LINK || this.getRoomSetting(`SKIP_STRUCTURE_${structureType}`)) {
       continue
     }
     if (!nextLevelStructureCount[structureType] || nextLevelStructureCount[structureType] <= 0) {


### PR DESCRIPTION
Right now the system doesn't plan "mining links" or order the link construction in any sane way. This PR removes links from being constructed, with the idea that they'll get added back in with a PR that also handles the above issues.