### PR TITLE
Reduce maintenance `healthThreshold` to 80%

### DIFF
--- a/src/programs/city/publicworks.js
+++ b/src/programs/city/publicworks.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const healthThreshold = 0.9
+const healthThreshold = 0.8
 const maintainStructures = [
   STRUCTURE_ROAD,
   STRUCTURE_CONTAINER


### PR DESCRIPTION
Right now towers are over repairing roads close to them. Reducing the `healthThreshold` will make maintenance more efficient.