### PR TITLE
Economy walls

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
       "ECONOMY_BURSTING",
       "ECONOMY_CRASHED",
       "ECONOMY_DEVELOPING",
+      "ECONOMY_FALTERING",
       "ECONOMY_STABLE",
       "ECONOMY_SURPLUS",
       "qlib",

--- a/src/extends/room/economy.js
+++ b/src/extends/room/economy.js
@@ -1,20 +1,24 @@
 'use strict'
 
 global.ECONOMY_CRASHED = 0
-global.ECONOMY_DEVELOPING = 1
-global.ECONOMY_STABLE = 2
-global.ECONOMY_SURPLUS = 3
-global.ECONOMY_BURSTING = 4
+global.ECONOMY_FALTERING = 1
+global.ECONOMY_DEVELOPING = 2
+global.ECONOMY_STABLE = 3
+global.ECONOMY_SURPLUS = 4
+global.ECONOMY_BURSTING = 5
 
 const economySettings = {
   'EXPAND_FROM': ECONOMY_DEVELOPING,
-  'BUILD_STRUCTURES': ECONOMY_STABLE,
-  'UPGRADE_CONTROLLERS': ECONOMY_STABLE,
+  'WALLBUILDERS': ECONOMY_DEVELOPING,
+  'BUILD_STRUCTURES': ECONOMY_DEVELOPING,
+
   'EXTRACT_MINERALS': ECONOMY_STABLE,
+  'UPGRADE_CONTROLLERS': ECONOMY_STABLE,
+
   'EXTRA_UPGRADERS': ECONOMY_SURPLUS,
-  'MORE_EXTRA_UPGRADERS': ECONOMY_BURSTING,
-  'EXTRA_WALLBUILDERS': ECONOMY_BURSTING,
-  'WALLBUILDERS': ECONOMY_STABLE
+  'EXTRA_WALLBUILDERS': ECONOMY_SURPLUS,
+
+  'MORE_EXTRA_UPGRADERS': ECONOMY_BURSTING
 }
 
 Room.prototype.isEconomyCapable = function (key) {
@@ -36,8 +40,13 @@ Room.prototype.getEconomyLevel = function () {
     return ECONOMY_CRASHED
   }
 
-  // When fully developed between 15000 and 300000
-  if (energy < desiredBuffer) {
+  // When fully developed between 15000 and 280000
+  if (energy < (desiredBuffer - 20000)) {
+    return ECONOMY_FALTERING
+  }
+
+  // When fully developed between 280000 and 300000
+  if (energy < (desiredBuffer)) {
     return ECONOMY_DEVELOPING
   }
 
@@ -51,7 +60,7 @@ Room.prototype.getEconomyLevel = function () {
     return ECONOMY_BURSTING
   }
 
-  // When fully developed over 300000
+  // When fully developed over 320000
   return ECONOMY_SURPLUS
 }
 

--- a/src/programs/city/fortify.js
+++ b/src/programs/city/fortify.js
@@ -60,7 +60,7 @@ class CityFortify extends kernel.process {
     let quantity = 0
     if (this.room.isEconomyCapable('WALLBUILDERS')) {
       if (target instanceof ConstructionSite || target.hits < desiredHitpoints) {
-        quantity += 2
+        quantity += 1
       }
       if (this.room.isEconomyCapable('EXTRA_WALLBUILDERS')) {
         quantity += 2


### PR DESCRIPTION
This creates a new economy level, `ECONOMY_FALTERING`. This puts more distance between `ECONOMY_DEVELOPING` and the floor, making it a more useful setting to use.

| Level               | Range (PRL8) |
|---------------|-------|
| CRASHED       | < 15000 |
| FALTERING    | < 280000 |
| DEVELOPING | < 300000 |
| STABLE          | < 320000 |
| SURPLUS       | >= 320000 |
| BURSTING     | >= 320000 (and storage more than 90% full) |

This PR also adjusts various settings to take advantage of this, including setting the `fortify` program to run before upgraders. This also drops the number of wall builders created at that level to a singler builder so it doesn't put so much strain on the economy that it never creates upgraders.