### PR TITLE
Logging cleanup - better groupings, ability to suppress by severity

### DIFF
--- a/src/qos/kernel.js
+++ b/src/qos/kernel.js
@@ -32,7 +32,7 @@ class QosKernel {
 
   start () {
     // Announce new uploads
-    Logger.log(`Initializing Kernel for tick ${Game.time}`, LOG_INFO, 'kernel')
+    Logger.log(`Initializing Kernel for tick ${Game.time}`, LOG_TRACE, 'kernel')
     if (!Memory.qos.script_version || Memory.qos.script_version !== SCRIPT_VERSION) {
       Logger.log(`New script upload detected: ${SCRIPT_VERSION}`, LOG_WARN)
       Memory.qos.script_version = SCRIPT_VERSION
@@ -54,6 +54,7 @@ class QosKernel {
   }
 
   cleanMemory () {
+    Logger.log('Cleaning memory', LOG_TRACE, 'kernel')
     let i
     for (i in Memory.creeps) { // jshint ignore:line
       if (!Game.creeps[i]) {
@@ -79,7 +80,7 @@ class QosKernel {
           processName += ' ' + descriptor
         }
 
-        Logger.log(`Running ${processName} (pid ${runningProcess.pid})`, LOG_INFO, 'kernel')
+        Logger.log(`Running ${processName} (pid ${runningProcess.pid})`, LOG_TRACE, 'kernel')
         const startCpu = Game.cpu.getUsed()
         runningProcess.run()
         let performanceName = runningProcess.name

--- a/src/qos/logger.js
+++ b/src/qos/logger.js
@@ -35,6 +35,10 @@ class Logger {
       qlib.notify.send(message, 500)
     }
 
+    if (Memory.loglevel && Memory.loglevel > severity) {
+      return
+    }
+
     let attributes = ''
     let tag
     if (tags) {
@@ -53,7 +57,7 @@ class Logger {
     try {
       this.log(JSON.stringify(data), severity, group)
     } catch (err) {
-      this.log('Unable to log data due to circular dependency')
+      this.log('Unable to log data due to circular dependency', severity, group)
     }
   }
 

--- a/src/qos/performance.js
+++ b/src/qos/performance.js
@@ -37,7 +37,7 @@ class Performance {
       let average = cpu / count
       report += `${program}\t ${average.toFixed(3)}\t${max.toFixed(3)}\t${cpu.toFixed(3)}\t${count}\n`
     }
-    Logger.log(report)
+    Logger.log(report, LOG_WARN, 'performance')
   }
 
   reportHtml () {
@@ -92,7 +92,7 @@ class Performance {
       report += '</tr>'
     }
     report += '</table>'
-    Logger.log(report)
+    Logger.log(report, LOG_WARN, 'performance')
   }
 
   clear () {


### PR DESCRIPTION
Log messages can be suppressed by setting `Memory.loglevel` to the desired minimum logging level.

This also drops the logging level on some kernel messages, making them easier to either suppress or filter out (on the screepsdashboard `severity: >3` will only show errors, for example).

Finally, some log messages have had their groups set.