### PR TITLE
Have haulers keep away from minerals until frackers are in place

### DIFF
--- a/src/programs/city/extract.js
+++ b/src/programs/city/extract.js
@@ -22,10 +22,10 @@ class CityExtract extends kernel.process {
     const frackerCluster = this.getCluster('frackers', this.room)
     const haulerCluster = this.getCluster('haulers', this.room)
     const frackers = frackerCluster.getCreeps()
-    const frackersToEmpty = _.filter(frackers, function (fracker) {
-      if (!fracker.pos.isNearTo(mineral)) {
-        return false
-      }
+    const frackersInPlace = _.filter(frackers, function (fracker) {
+      return fracker.pos.isNearTo(mineral)
+    })
+    const frackersToEmpty = _.filter(frackersInPlace, function (fracker) {
       return _.sum(fracker.carry) > 0
     })
 
@@ -66,7 +66,11 @@ class CityExtract extends kernel.process {
       }
 
       if (frackersToEmpty.length < 1) {
-        if (hauler.pos.getRangeTo(mineral) > 2) {
+        const rangeToMineral = hauler.pos.getRangeTo(mineral)
+        const idealDistance = frackersInPlace.length ? 2 : 5
+        if (rangeToMineral < idealDistance) {
+          hauler.travelTo(storage)
+        } else if (rangeToMineral > idealDistance) {
           hauler.travelTo(mineral)
         }
         return


### PR DESCRIPTION
Sometimes the haulers block the frackers from getting to the minerals, which burns CPU and wastes energy as we spawn useless creeps. This update has haulers wait further away from the minerals when the frackers are not in place.

<img width="121" alt="screen shot 2017-12-04 at 5 30 20 pm" src="https://user-images.githubusercontent.com/121709/33585450-29578b22-d919-11e7-99fb-3c7f6bb07cca.png">
