### PR TITLE
Change expansion scoring - favor catalyst, ignore exits

### DIFF
--- a/src/extends/room/territory.js
+++ b/src/extends/room/territory.js
@@ -165,21 +165,22 @@ Room.prototype.getMineScore = function (roomName) {
 // ex, 2 sources at 10 points is 25% of the overall score.
 // Penalties are not counts as they add "zero" to the score at best.
 
-/* Resources - 22 - 55% of total score not counting penalties */
+/* Resources - 24 - 60% of total score not counting penalties */
 /* No penalties */
 const CITY_WEIGHTS_TWO_SOURCES = 9 // Will be zero if less than 2 sources.
-const CITY_WEIGHTS_MINERAL_MARKET = 4
+const CITY_WEIGHTS_MINERAL_MARKET = 3
 const CITY_WEIGHTS_MINERAL_EMPIRE_NEED = 3
+const CITY_WEIGHTS_MINERAL_CATALYST = 3
 const CITY_WEIGHTS_REGION_RESOURCES = 2
 const CITY_WEIGHTS_NEIGHBOR_SOURCES = 4
 
-/* Terrain - 6 - 15% of total score not counting penalties  */
+/* Terrain - 4 - 10% of total score not counting penalties  */
 /* Up to 5 points in penalties */
 const CITY_WEIGHTS_SWAMPINESS = -5
 const CITY_WEIGHTS_WALKABILITY = 4
 
 // Currently looks for rooms with fewer exit tiles
-const CITY_WEIGHTS_DEFENSIBILITY = 2
+const CITY_WEIGHTS_DEFENSIBILITY = 0
 
 /* Location - 12 - 30% of total score not counting penalties  */
 /* Up to 12 points in penalties */
@@ -253,6 +254,7 @@ Room.getCityScore = function (roomName) {
   score += intel[INTEL_SWAMPINESS] * CITY_WEIGHTS_SWAMPINESS
   score += getMineralMarketScore(intel[INTEL_MINERAL]) * CITY_WEIGHTS_MINERAL_MARKET
   score += getMineralEmpireNeedsScore(intel[INTEL_MINERAL]) * CITY_WEIGHTS_MINERAL_EMPIRE_NEED
+  score += intel[INTEL_MINERAL] === RESOURCE_CATALYST ? CITY_WEIGHTS_MINERAL_CATALYST : 0
   score += getDefensibilityScore(roomName) * CITY_WEIGHTS_DEFENSIBILITY
   score += getRoomTypeScore(roomName) * CITY_WEIGHTS_ROOMTYPE
   score += getEmpireClutterScore(roomName) * CITY_WEIGHTS_EMPIRE_CLUTTERED


### PR DESCRIPTION
* Drop `CITY_WEIGHTS_DEFENSIBILITY` to zero. This was originally set to two before the wall/rampart program was put together. Since `Quorum` isn’t actually building exit walls it doesn’t make sense anymore to take them into account when selecting new rooms.

* Add new `CITY_WEIGHTS_MINERAL_CATALYST` and set it to 3 (two points from above, and one point taken from CITY_WEIGHTS_MINERAL_MARKET). This triggers if the room has catalyst. This keeps `Quorum` from ignoring catalyst on new shards or private servers (where NPC prices tend to mostly be equal at the start) and helps take into account the rarity of catalyst.