### PR TITLE
Fix empire_expand program

### DIFF
--- a/src/programs/empire/expand.js
+++ b/src/programs/empire/expand.js
@@ -136,8 +136,8 @@ class EmpireExpand extends kernel.process {
         return this.data.candidates.pop()
       } else {
         // If all candidates have been invalidated clear data and try again
-        delete this.data.candidates;
-        delete this.data.candidateList;
+        delete this.data.candidates
+        delete this.data.candidateList
       }
     }
 

--- a/src/programs/empire/expand.js
+++ b/src/programs/empire/expand.js
@@ -131,13 +131,20 @@ class EmpireExpand extends kernel.process {
 
   getNextCandidate () {
     // If a candidate list already exists use the best scoring candidate from the list.
-    if (this.data.candidates && this.data.candidates.length > 0) {
-      return this.data.candidates.pop()
+    if (this.data.candidates) {
+      if (this.data.candidates.length > 0) {
+        return this.data.candidates.pop()
+      } else {
+        // If all candidates have been invalidated clear data and try again
+        delete this.data.candidates;
+        delete this.data.candidateList;
+      }
     }
 
-    if (typeof this.data.candidateList === 'undefined' || !this.data.candidates || this.data.candidates.length <= 0) {
+    if (typeof this.data.candidateList === 'undefined') {
       this.data.candidateList = this.getCandidateList()
     }
+
     if (!this.data.candidateScores) {
       this.data.candidateScores = {}
     }
@@ -145,7 +152,7 @@ class EmpireExpand extends kernel.process {
     const startCPU = Game.cpu.getUsed()
     while (this.data.candidateList.length > 0) {
       const testRoom = this.data.candidateList.pop()
-      const score = this.data.candidateScores[testRoom] || Room.getCityScore(testRoom)
+      const score = Room.getCityScore(testRoom)
       if (score) {
         this.data.candidateScores[testRoom] = score
       }

--- a/src/programs/empire/expand.js
+++ b/src/programs/empire/expand.js
@@ -145,7 +145,7 @@ class EmpireExpand extends kernel.process {
     const startCPU = Game.cpu.getUsed()
     while (this.data.candidateList.length > 0) {
       const testRoom = this.data.candidateList.pop()
-      const score = Room.getCityScore(testRoom)
+      const score = this.data.candidateScores[testRoom] || Room.getCityScore(testRoom)
       if (score) {
         this.data.candidateScores[testRoom] = score
       }


### PR DESCRIPTION
**Expected behaviour**
Score each entry of the `candidateList` one after another until every room has a score. Only calculate a certain amount of rooms, depending on CPU, each tick and continue at next execution.

**Actual behaviour**
The `candidateList` is refilled every tick if no `candidates` have been found yet, this results in a recalculation of room scores which gets aborted after a certain amount of ticks. If the `candidateList` is too long this will happen every tick and not find any suitable candidates ever.