### PR TITLE
Fix an issue with mineral market score calculation

### DIFF
--- a/src/extends/room/territory.js
+++ b/src/extends/room/territory.js
@@ -310,7 +310,7 @@ Room.testRoomScore = function (roomName) {
 function getMineralMarketScore (mineral) {
   const max = qlib.market.getHighestMineralValue()
   const cost = qlib.market.getAveragePrice(mineral, ORDER_SELL)
-  return cost / max
+  return cost / max || 0
 }
 
 function getMineralEmpireNeedsScore (mineral) {


### PR DESCRIPTION
If the average market price for a mineral is 0 because no sell orders
could be found this functions will divide by 0 which results in NaN.

This cascades to our room scoring algorithm which causes it to fail over
and over since the room score returns null.