### PR TITLE
Have rooms send energy to rooms that need it

### DIFF
--- a/src/extends/room/control.js
+++ b/src/extends/room/control.js
@@ -39,7 +39,8 @@ let roomLevelOptions = {
   },
   8: {
     'UPGRADERS_QUANTITY': 1,
-    'REMOTE_MINES': 3
+    'REMOTE_MINES': 3,
+    'SHARE_ENERGY': true
   }
 }
 

--- a/src/extends/room/economy.js
+++ b/src/extends/room/economy.js
@@ -7,6 +7,7 @@ global.ECONOMY_STABLE = 3
 global.ECONOMY_SURPLUS = 4
 global.ECONOMY_BURSTING = 5
 
+// Will return true for economic levels at or above these values.
 const economySettings = {
   'SUPPLY_TERMINAL': ECONOMY_FALTERING,
 
@@ -19,15 +20,25 @@ const economySettings = {
 
   'EXTRA_UPGRADERS': ECONOMY_SURPLUS,
   'EXTRA_WALLBUILDERS': ECONOMY_SURPLUS,
+  'SHARE_ENERGY': ECONOMY_SURPLUS,
 
-  'MORE_EXTRA_UPGRADERS': ECONOMY_BURSTING
+  'MORE_EXTRA_UPGRADERS': ECONOMY_BURSTING,
+  'DUMP_ENERGY': ECONOMY_BURSTING
+}
+
+// Will return true for economic levels at or below these values.
+const economyNegativeSettings = {
+  'REQUEST_ENERGY': ECONOMY_FALTERING
 }
 
 Room.prototype.isEconomyCapable = function (key) {
-  if (!economySettings[key]) {
-    return false
+  if (Number.isInteger(economySettings[key])) {
+    return this.getEconomyLevel() >= economySettings[key]
   }
-  return this.getEconomyLevel() >= economySettings[key]
+  if (Number.isInteger(economyNegativeSettings[key])) {
+    return this.getEconomyLevel() <= economyNegativeSettings[key]
+  }
+  return false
 }
 
 Room.prototype.getEconomyLevel = function () {

--- a/src/extends/terminal.js
+++ b/src/extends/terminal.js
@@ -23,7 +23,7 @@ if (!StructureTerminal.prototype.__send) {
   StructureTerminal.prototype.send = function (resourceType, amount, destination, description) {
     const ret = this.__send(resourceType, amount, destination, description)
     if (ret === OK) {
-      let log = `Termail sent ${amount} ${resourceType} to ${destination}`
+      let log = `Terminal sent ${amount} ${resourceType} to ${destination}`
       if (description) {
         log += `: ${description}`
       }

--- a/src/extends/terminal.js
+++ b/src/extends/terminal.js
@@ -1,0 +1,37 @@
+'use strict'
+
+StructureTerminal.prototype.canReceive = function (resource = false) {
+  const buffer = this.getBuffer()
+  if (buffer < 50000) {
+    if (buffer > 5000) {
+      // Transfer energy to help terminal drain itself of excess resources.
+      if (resource === RESOURCE_ENERGY && this.store[RESOURCE_ENERGY] < 5000) {
+        return true
+      }
+    }
+    return false
+  }
+  return true
+}
+
+StructureTerminal.prototype.getBuffer = function () {
+  return this.storeCapacity - _.sum(this.store)
+}
+
+if (!StructureTerminal.prototype.__send) {
+  StructureTerminal.prototype.__send = StructureTerminal.prototype.send
+  StructureTerminal.prototype.send = function (resourceType, amount, destination, description) {
+    const ret = this.__send(resourceType, amount, destination, description)
+    if (ret === OK) {
+      let log = `Termail sent ${amount} ${resourceType} to ${destination}`
+      if (description) {
+        log += `: ${description}`
+      }
+      Logger.log(log, LOG_INFO)
+    } else {
+      let log = `Terminal failed to send ${amount} ${resourceType} to ${destination} due to error ${ret}`
+      Logger.log(log, LOG_ERROR)
+    }
+    return ret
+  }
+}

--- a/src/lib/empire.js
+++ b/src/lib/empire.js
@@ -6,6 +6,25 @@ class Empire {
     }
     return this._dossier
   }
+
+  get terminals () {
+    if (!this._terminals) {
+      this._terminals = []
+      for (const city of this.cities) {
+        if (Game.rooms[city] && Game.rooms[city].terminal) {
+          this._terminals.push(Game.rooms[city].terminal)
+        }
+      }
+    }
+    return this._terminals
+  }
+
+  get cities () {
+    if (!this._cities) {
+      this._cities = Room.getCities()
+    }
+    return this._cities
+  }
 }
 
 module.exports = Empire

--- a/src/main.js
+++ b/src/main.js
@@ -52,6 +52,7 @@ require('extends_room_spawning')
 require('extends_room_structures')
 require('extends_room_territory')
 require('extends_roomposition')
+require('extends_terminal')
 require('extends_source')
 
 const QosKernel = require('qos_kernel')


### PR DESCRIPTION
Rooms with either bursting economies *or* PRL8 with a surplus economy will send energy to rooms with failing economies or to the lowest room level. If rooms are tied for lowest PRL then the one closest to leveling up will be chosen.

The PR also does a few things to make sure rooms are flooded with energy, to the point where their terminals can't be used.