### PR TITLE
Fix a Bug Serializing Rooms in W00S00 Quadrant

### DIFF
--- a/src/extends/room/meta.js
+++ b/src/extends/room/meta.js
@@ -27,9 +27,9 @@ Room.serializeName = function (name) {
   const coords = Room.getCoordinates(name)
   let quad
   if (coords.x_dir === 'E') {
-    quad = coords.y === 'N' ? '0' : '1'
+    quad = coords.y_dir === 'N' ? '0' : '1'
   } else {
-    quad = coords.y === 'S' ? '2' : '3'
+    quad = coords.y_dir === 'S' ? '2' : '3'
   }
   const x = String.fromCodePoint(+coords.x + +unicodeModifier)
   const y = String.fromCodePoint(+coords.y + +unicodeModifier)


### PR DESCRIPTION
Unable to correctly serialize any rooms in the W00S00 quadrants as they would be deserialized as W00N00.