### PR TITLE
Scheduler and Performance Report Fixes

### DIFF
--- a/src/qos/performance.js
+++ b/src/qos/performance.js
@@ -41,7 +41,7 @@ class Performance {
   }
 
   reportHtml () {
-    const numTicks = Game.time - Memory.qos.performance.start
+    const numTicks = (Game.time - Memory.qos.performance.start) + 1
 
     let report = '\n'
 

--- a/src/qos/scheduler.js
+++ b/src/qos/scheduler.js
@@ -103,6 +103,11 @@ class Scheduler {
 
       this.memory.processes.running = this.memory.processes.queues[x].shift()
 
+      // Don't run this pid twice in a single tick.
+      if (this.memory.processes.completed.includes(this.memory.processes.running)) {
+        continue
+      }
+
       // If process doesn't exist anymore don't use it.
       if (!this.memory.processes.index[this.memory.processes.running]) {
         continue


### PR DESCRIPTION
Fixes a bug where processes could be run more than once in a tick.

Fixes a bug in the performance module that miscalculated the number of ticks recorded.

resolves #277 