### PR TITLE
Low Level Upgrader Efficiency

### DIFF
--- a/src/extends/controller.js
+++ b/src/extends/controller.js
@@ -25,7 +25,7 @@ StructureController.prototype.isTimingOut = function () {
   if (!this.level || !CONTROLLER_DOWNGRADE[this.level]) {
     return false
   }
-  return CONTROLLER_DOWNGRADE[this.level] - this.ticksToDowngrade > 4000
+  return (CONTROLLER_DOWNGRADE[this.level] - this.ticksToDowngrade > 4000) || this.ticksToDowngrade < 4000
 }
 
 StructureController.prototype.canSafemode = function () {

--- a/src/roles/upgrader.js
+++ b/src/roles/upgrader.js
@@ -24,9 +24,10 @@ class Upgrader extends MetaRole {
     if (creep.carry[RESOURCE_ENERGY] / creep.carryCapacity < 0.5) {
       if (link && link.energy > 0 && creep.pos.isNearTo(link)) {
         creep.withdraw(link, RESOURCE_ENERGY)
-      } else if (creep.recharge()) {
-        return
       }
+    }
+    if (creep.recharge()) {
+      return
     }
 
     if (!creep.room.controller.sign || creep.room.controller.sign.text !== CONTROLLER_MESSAGE) {


### PR DESCRIPTION
These changes prevent controller timeouts at RCL2 and prevents a bug where upgraders were really inefficient without links and storage.