### PR TITLE
When bucket > BUCKET_CEILING don't use more than 5% of bucket

### DIFF
--- a/src/qos/kernel.js
+++ b/src/qos/kernel.js
@@ -140,7 +140,7 @@ class QosKernel {
 
   getCpuLimit () {
     if (Game.cpu.bucket > BUCKET_CEILING) {
-      return Game.cpu.tickLimit - CPU_BUFFER
+      return Math.min(Game.cpu.tickLimit - CPU_BUFFER, Game.cpu.bucket * 0.05)
     }
 
     if (Game.cpu.bucket < BUCKET_EMERGENCY) {


### PR DESCRIPTION
This helps deal with an issue on private servers where Game.cpu.tickLimit could be higher than the bucket.