### PR TITLE
Increase number of remote mines per room

### DIFF
--- a/src/extends/room/control.js
+++ b/src/extends/room/control.js
@@ -35,11 +35,12 @@ let roomLevelOptions = {
   7: {
     'RESERVER_COUNT': 1,
     'ALLOW_MINING_SCALEBACK': false,
+    'REMOTE_MINES': 3,
     'ALWAYS_SAFEMODE': true
   },
   8: {
     'UPGRADERS_QUANTITY': 1,
-    'REMOTE_MINES': 3,
+    'REMOTE_MINES': 4,
     'SHARE_ENERGY': true
   }
 }


### PR DESCRIPTION
* From 2 to 3 at PRL7.
* From 3 to 4 at PRL8.