### PR TITLE
Revert "Increase number of remote mines per room"

### DIFF
--- a/src/extends/room/control.js
+++ b/src/extends/room/control.js
@@ -35,12 +35,11 @@ let roomLevelOptions = {
   7: {
     'RESERVER_COUNT': 1,
     'ALLOW_MINING_SCALEBACK': false,
-    'REMOTE_MINES': 3,
     'ALWAYS_SAFEMODE': true
   },
   8: {
     'UPGRADERS_QUANTITY': 1,
-    'REMOTE_MINES': 4,
+    'REMOTE_MINES': 3,
     'SHARE_ENERGY': true
   }
 }


### PR DESCRIPTION
Reverts ScreepsQuorum/screeps-quorum#298

Unfortunately the system didn't scale properly- it should have added one mine at a time, waited, and gauged CPU levels. Instead it just added a bunch and it's tanking the CPU.