### PR TITLE
Reduce intel program CPU usage

### DIFF
--- a/src/extends/room/movement.js
+++ b/src/extends/room/movement.js
@@ -60,11 +60,13 @@ Room.getStructuresCostmatrix = function (roomname, opts) {
   }
   const cacheLabel = `${Room.serializeName(roomname)}_${(flags >>> 0)}`
 
-  let cmSerialized = sos.lib.cache.get(cacheLabel, {
-    ttl: Game.rooms[roomname] ? 25 : false
-  })
-  if (cmSerialized) {
-    return PathFinder.CostMatrix.deserialize(cmSerialized)
+  if (!opts.noCache) {
+    let cmSerialized = sos.lib.cache.get(cacheLabel, {
+      ttl: Game.rooms[roomname] ? 25 : false
+    })
+    if (cmSerialized) {
+      return PathFinder.CostMatrix.deserialize(cmSerialized)
+    }
   }
   const cm = new PathFinder.CostMatrix()
 
@@ -83,14 +85,22 @@ Room.getStructuresCostmatrix = function (roomname, opts) {
     const room = Game.rooms[roomname]
     const structures = room.find(FIND_STRUCTURES)
     for (let structure of structures) {
-      if (!opts.ignoreRoads && structure.structureType === STRUCTURE_ROAD) {
+      if (structure.structureType === STRUCTURE_ROAD) {
+        if (!opts.ignoreRoads) {
+          continue
+        }
         cm.set(structure.pos.x, structure.pos.y, 1)
         continue
       }
-      if (!opts.ignorePortals && structure.structureType === STRUCTURE_PORTAL) {
+      if (structure.structureType === STRUCTURE_PORTAL) {
+        if (!opts.ignorePortals) {
+          continue
+        }
         cm.set(structure.pos.x, structure.pos.y, 255)
       }
-      if (!opts.ignoreDestructibleStructures) {
+      if (opts.ignoreDestructibleStructures) {
+        continue
+      } else {
         if (!structure.my && structure.structureType === STRUCTURE_RAMPART) {
           cm.set(structure.pos.x, structure.pos.y, 255)
         } else if (OBSTACLE_OBJECT_TYPES.indexOf(structure.structureType) >= 0) {
@@ -118,11 +128,13 @@ Room.getStructuresCostmatrix = function (roomname, opts) {
     }
   }
 
-  sos.lib.cache.set(cacheLabel, cm.serialize(), {
-    persist: true,
-    maxttl: 3000,
-    compress: true
-  })
+  if (!opts.noCache) {
+    sos.lib.cache.set(cacheLabel, cm.serialize(), {
+      persist: true,
+      maxttl: 3000,
+      compress: true
+    })
+  }
   return cm
 }
 

--- a/src/extends/room/movement.js
+++ b/src/extends/room/movement.js
@@ -86,14 +86,14 @@ Room.getStructuresCostmatrix = function (roomname, opts) {
     const structures = room.find(FIND_STRUCTURES)
     for (let structure of structures) {
       if (structure.structureType === STRUCTURE_ROAD) {
-        if (!opts.ignoreRoads) {
+        if (opts.ignoreRoads) {
           continue
         }
         cm.set(structure.pos.x, structure.pos.y, 1)
         continue
       }
       if (structure.structureType === STRUCTURE_PORTAL) {
-        if (!opts.ignorePortals) {
+        if (opts.ignorePortals) {
           continue
         }
         cm.set(structure.pos.x, structure.pos.y, 255)


### PR DESCRIPTION
* Don’t cache costmatrixes generated for intel.
* Don’t scan rooms reserved by current player.
* Increase scans of unowned rooms from 60 to 2000 ticks.
* Increase scans of owned rooms from 60 to 100 ticks.
* Add random variance to INTEL_UPDATED to spread out room scans.
* Only look for blocked exits in rooms with walls or ramparts.