### PR TITLE
fix `getTimeSinceEvent` by passing event to `this.getEventTime`

### DIFF
--- a/src/lib/events.js
+++ b/src/lib/events.js
@@ -19,7 +19,7 @@ class Events {
   }
 
   getTimeSinceEvent (event) {
-    return Game.time - this.getEventTime()
+    return Game.time - this.getEventTime(event)
   }
 
   hasEventHappened (event) {


### PR DESCRIPTION
This bug is what caused all of the mines to be added at once when the new mining limits were added.