### PR TITLE
Increase miner WORK parts in remote rooms

### DIFF
--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -113,7 +113,7 @@ class CityMine extends kernel.process {
       minerQuantity = 0
     }
 
-    miners.sizeCluster('miner', minerQuantity, {'priority': 2})
+    miners.sizeCluster('miner', minerQuantity, {'priority': 2, 'remote': this.remote})
     miners.forEach(function (miner) {
       if (miner.pos.getRangeTo(minerPos) !== 0) {
         miner.travelTo(minerPos)

--- a/src/roles/miner.js
+++ b/src/roles/miner.js
@@ -5,15 +5,24 @@ const MetaRole = require('roles_meta')
 class Miner extends MetaRole {
   constructor () {
     super()
-    this.defaultEnergy = 800
+    this.defaultEnergy = 950
   }
 
   getBuild (room, options) {
     this.setBuildDefaults(room, options)
-    const base = [MOVE, CARRY, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE]
-    if (options.energy >= 800) {
-      return base
+    let base
+    if (options.remote) {
+      base = [MOVE, CARRY, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE, MOVE, WORK]
+      if (options.energy >= 950) {
+        return base
+      }
+    } else {
+      base = [MOVE, CARRY, WORK, WORK, WORK, WORK, WORK, WORK, MOVE, MOVE]
+      if (options.energy >= 800) {
+        return base
+      }
     }
+
     return Creep.buildFromTemplate(base, options.energy)
   }
 }


### PR DESCRIPTION
* Drop from average of 0.18 to 0.16 CPU per tick per miner.
* Allow for 21% (up from 8%) of ticks to be skipped without losing mineral or container (can run more mines at once).
* This drops energy profits by drop by 1.1% (150 energy).
