### PR TITLE
New Consensus Options - consensusdelay and locklicense

### DIFF
--- a/.gitconsensus.yaml
+++ b/.gitconsensus.yaml
@@ -22,6 +22,11 @@ timeout: 168
 # Don't count any vote from a user who votes for multiple options
 prevent_doubles: true
 
+# Do not allow changes to the license.
+locklicense: true
+
+# Wait for at least four days before merging any new consensus rules.
+consensusdelay: 96
 
 #
 # Disabled Consensus Rules


### PR DESCRIPTION
* Lock License, as we can’t legally change it without everyone’s permission.

* Don’t allow new consensus rules to be merged for at least four days.