### PR TITLE
Don't mine rooms blocked by hostiles

### DIFF
--- a/src/extends/room/territory.js
+++ b/src/extends/room/territory.js
@@ -61,8 +61,8 @@ Room.prototype.addMine = function (mine) {
 }
 
 Room.prototype.removeMine = function (mine) {
-  const id = this.getMineId()
-  if (id < 0) {
+  const id = this.getMineId(mine)
+  if (!id || id < 0) {
     return
   }
 

--- a/src/extends/room/territory.js
+++ b/src/extends/room/territory.js
@@ -140,7 +140,12 @@ Room.prototype.getMineScore = function (roomName) {
   if (Room.isSourcekeeper(roomName)) {
     return false
   }
-  let distance = Game.map.findRoute(this.name, roomName).length
+  const route = qlib.map.findRoute(this.name, roomName, {'avoidHostileRooms': true})
+  if (route === ERR_NO_PATH) {
+    return false
+  }
+
+  const distance = route.length
   if (distance > MINE_MAX_DISTANCE) {
     return false
   }

--- a/src/lib/map.js
+++ b/src/lib/map.js
@@ -2,7 +2,11 @@
 module.exports.findRoute = function (fromRoom, toRoom, opts = {}) {
   if (!opts.routeCallback) {
     opts.routeCallback = function (toRoom, fromRoom) {
-      return module.exports.getRoomScore(toRoom, fromRoom)
+      const score = module.exports.getRoomScore(toRoom, fromRoom)
+      if (opts.avoidHostileRooms && score > PATH_WEIGHT_NEUTRAL) {
+        return Infinity
+      }
+      return score
     }
     if (!opts.ignoreCache) {
       const cacheLabel = `route_${Room.serializeName(fromRoom)}_${Room.serializeName(toRoom)}`

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -47,6 +47,15 @@ class CityMine extends kernel.process {
         return this.suicide()
       }
 
+      // If the mine is not reachable remove it.
+      if (!Game.rooms[this.data.mine]) {
+        const route = qlib.map.findRoute(this.data.room, this.data.mine, {'avoidHostileRooms': true})
+        if (route === ERR_NO_PATH) {
+          //this.room.removeMine(this.data.mine)
+          //return this.suicide()
+        }
+      }
+
       this.remote = true
       this.scout()
       this.defend()

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -51,8 +51,8 @@ class CityMine extends kernel.process {
       if (!Game.rooms[this.data.mine]) {
         const route = qlib.map.findRoute(this.data.room, this.data.mine, {'avoidHostileRooms': true})
         if (route === ERR_NO_PATH) {
-          //this.room.removeMine(this.data.mine)
-          //return this.suicide()
+          this.room.removeMine(this.data.mine)
+          return this.suicide()
         }
       }
 


### PR DESCRIPTION
* Add new option to `qlib.map.findRoute` for avoiding hostile rooms.
* Don’t select mines that are blocked by hostile rooms.
* Kill existing mines when blocked by hostile rooms.