### PR TITLE
Monitor priority 9 (the "wall" dividing low and high priority)

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -60,7 +60,8 @@ global.MINERALS_EXTRACTABLE = [
 // Which priorities to monitor.
 global.MONITOR_PRIORITIES = _.uniq([
   PRIORITIES_CREEP_DEFAULT,
-  PRIORITIES_DEFAULT
+  PRIORITIES_DEFAULT,
+  9
 ])
 
 global.AGGRESSION_SCORES = {}


### PR DESCRIPTION
This will make it easier to see when low priority processes are being starved out.