### PR TITLE
Pathfinding tweaks

### DIFF
--- a/src/extends/creep/movement.js
+++ b/src/extends/creep/movement.js
@@ -100,7 +100,7 @@ Creep.prototype.travelTo = function (pos, opts = {}) {
 
   if (!moveToOpts.direct && this.room.name !== pos.roomName) {
     if (!moveToOpts.allowedRooms) {
-      moveToOpts.allowedRooms = []
+      moveToOpts.allowedRooms = [this.room.name, pos.roomName]
     }
     const worldRoute = qlib.map.findRoute(this.room.name, pos.roomName, moveToOpts)
     if (Number.isInteger(worldRoute)) {

--- a/src/extends/creep/movement.js
+++ b/src/extends/creep/movement.js
@@ -43,7 +43,7 @@ Creep.prototype.travelTo = function (pos, opts = {}) {
         moveToOpts.scores['WEIGHT_HOSTILE'] = Infinity
       }
       if (moveToOpts.ignoreHostileReservations) {
-        moveToOpts.scores['HOSTILE_RESERVATION'] = Infinity
+        moveToOpts.scores['WEIGHT_HOSTILE_RESERVATION'] = Infinity
       }
     }
   }

--- a/src/lib/map.js
+++ b/src/lib/map.js
@@ -8,6 +8,13 @@ module.exports.findRoute = function (fromRoom, toRoom, opts = {}) {
       }
       return score
     }
+
+    // If destination is not reachable do not attempt to route to it.
+    const toRoomScore = opts.routeCallback(toRoom)
+    if (toRoomScore === Infinity) {
+      return ERR_NO_PATH
+    }
+
     if (!opts.ignoreCache) {
       const cacheLabel = `route_${Room.serializeName(fromRoom)}_${Room.serializeName(toRoom)}`
       const cachedPath = sos.lib.cache.get(cacheLabel)

--- a/src/lib/map.js
+++ b/src/lib/map.js
@@ -64,7 +64,7 @@ module.exports.getRoomScore = function (toRoom, fromRoom, opts = {}) {
   }
   const scores = opts.scores ? opts.scores : {}
   if (Room.isSourcekeeper(toRoom)) {
-    return scores['SOURCEKEEPER'] ? scores['SOURCEKEEPER'] : PATH_WEIGHT_SOURCEKEEPER
+    return scores['WEIGHT_SOURCEKEEPER'] ? scores['WEIGHT_SOURCEKEEPER'] : PATH_WEIGHT_SOURCEKEEPER
   }
   if (Room.isHallway(toRoom)) {
     return scores['WEIGHT_HALLWAY'] ? scores['WEIGHT_HALLWAY'] : PATH_WEIGHT_HALLWAY


### PR DESCRIPTION
* Have `qlib.map.findRoute` return `ERR_NO_PATH` immediately if the destination room has a score of `Infinity` (meaning it isn't reachable).
* Make sure the cost matrix function always returns the CM for the current and destination rooms.
* Fix/normalize some parameter names.