### PR TITLE
Clear up traffic around core structures

### DIFF
--- a/src/extends/room/landmarks.js
+++ b/src/extends/room/landmarks.js
@@ -14,5 +14,14 @@ Room.prototype.getSuicideBooth = function () {
   }
 
   // Pick the location immediately above the spawn and recycle there.
-  return new RoomPosition(spawn.pos.x, spawn.pos.y - 1, spawn.room.name)
+  return new RoomPosition(spawn.pos.x - 1, spawn.pos.y, spawn.room.name)
+}
+
+Room.prototype.getFactotumHome = function () {
+  if (this.storage) {
+    return this.getPositionAt(this.storage.pos.x - 1, this.storage.pos.y + 1)
+  } else {
+    const suicideBooth = this.getSuicideBooth()
+    return this.getPositionAt(suicideBooth.pos.x, suicideBooth.pos.y - 1)
+  }
 }

--- a/src/extends/room/movement.js
+++ b/src/extends/room/movement.js
@@ -6,11 +6,31 @@ Room.getCostmatrix = function (roomname, opts = {}) {
   const cm = Room.getStructuresCostmatrix(roomname, opts)
 
   // Add in creeps
-  if (!opts.ignoreCreeps && Game.rooms[roomname]) {
+  if (Game.rooms[roomname]) {
     const room = Game.rooms[roomname]
-    const creeps = room.find(FIND_CREEPS)
-    for (let creep of creeps) {
-      cm.set(creep.pos.x, creep.pos.y, 255)
+
+    if (!opts.ignoreCreeps) {
+      const creeps = room.find(FIND_CREEPS)
+      for (let creep of creeps) {
+        cm.set(creep.pos.x, creep.pos.y, 255)
+      }
+    }
+
+    // Keep creeps from cluttering up core structure hallways.
+    if (!opts.ignoreCore && room.storage && room.storage.my) {
+      // Above terminal, near tower cluster entrance
+      cm.set(room.storage.pos.x - 1, room.storage.pos.y - 1, 15)
+      cm.set(room.storage.pos.x - 2, room.storage.pos.y - 1, 20)
+      cm.set(room.storage.pos.x - 3, room.storage.pos.y - 1, 20)
+
+      // Row below terminal and storage
+      cm.set(room.storage.pos.x - 1, room.storage.pos.y + 1, 15)
+      cm.set(room.storage.pos.x, room.storage.pos.y + 1, 15)
+      cm.set(room.storage.pos.x + 1, room.storage.pos.y + 1, 7)
+
+      // Column below terminal (first element covered above)
+      cm.set(room.storage.pos.x - 1, room.storage.pos.y + 2, 15)
+      cm.set(room.storage.pos.x - 1, room.storage.pos.y + 3, 7)
     }
   }
 

--- a/src/roles/factotum.js
+++ b/src/roles/factotum.js
@@ -50,7 +50,7 @@ class Factotum extends MetaRole {
       if (creep.pos.isNearTo(storageLink)) {
         creep.withdraw(storageLink, RESOURCE_ENERGY)
       } else {
-        creep.travelTo(storageLink)
+        this.goHome(creep)
       }
       return
     }
@@ -70,7 +70,7 @@ class Factotum extends MetaRole {
         if (creep.pos.isNearTo(suicideBooth)) {
           creep.pickup(resources[0])
         } else {
-          creep.travelTo(suicideBooth)
+          this.goHome(creep)
         }
       }
     }
@@ -175,13 +175,13 @@ class Factotum extends MetaRole {
         if (creep.pos.isNearTo(feeders[0])) {
           creep.transfer(feeders[0], reaction[0])
         } else {
-          creep.travelTo(feeders[0])
+          creep.travelTo(feeders[0], {'ignoreCore': true})
         }
       } else if (creep.carry[reaction[1]] && feeders[1].canFill()) {
         if (creep.pos.isNearTo(feeders[1])) {
           creep.transfer(feeders[1], reaction[1])
         } else {
-          creep.travelTo(feeders[1])
+          creep.travelTo(feeders[1], {'ignoreCore': true})
         }
       } else {
         delete creep.memory.filling
@@ -189,7 +189,7 @@ class Factotum extends MetaRole {
       }
     } else {
       if (!creep.pos.isNearTo(creep.room.storage)) {
-        creep.travelTo(creep.room.storage)
+        this.goHome(creep)
         return
       }
 
@@ -223,7 +223,7 @@ class Factotum extends MetaRole {
     if (creep.pos.isNearTo(lab)) {
       creep.withdraw(lab, lab.mineralType)
     } else {
-      creep.travelTo(lab)
+      creep.travelTo(lab, {'ignoreCore': true})
     }
   }
 
@@ -283,7 +283,7 @@ class Factotum extends MetaRole {
         const amount = need > creep.carry[RESOURCE_ENERGY] ? creep.carry[RESOURCE_ENERGY] : need
         creep.transfer(creep.room.terminal, RESOURCE_ENERGY, amount)
       } else {
-        creep.travelTo(creep.room.terminal)
+        this.goHome(creep)
       }
       return
     }
@@ -312,14 +312,14 @@ class Factotum extends MetaRole {
     if (creep.pos.isNearTo(structure)) {
       creep.transfer(structure, RESOURCE_ENERGY)
     } else {
-      creep.travelTo(structure)
+      creep.travelTo(structure, {'ignoreCore': true})
     }
   }
 
   emptyResources (creep) {
     // Must be near storage to empty creep.
     if (!creep.pos.isNearTo(creep.room.storage)) {
-      creep.travelTo(creep.room.storage)
+      this.goHome(creep)
       return
     }
 
@@ -351,10 +351,14 @@ class Factotum extends MetaRole {
       if (creep.pos.isNearTo(creep.room.terminal)) {
         creep.transfer(creep.room.terminal, resource)
       } else {
-        creep.travelTo(creep.room.terminal)
+        this.goHome(creep)
       }
     }
     return true
+  }
+
+  goHome (creep) {
+    return creep.travelTo(creep.room.getFactotumHome(), {'ignoreCore': true})
   }
 }
 

--- a/src/roles/filler.js
+++ b/src/roles/filler.js
@@ -74,7 +74,11 @@ class Filler extends MetaRole {
     if (creep.pos.isNearTo(structure)) {
       creep.transfer(structure, RESOURCE_ENERGY, Math.min(creep.carry[RESOURCE_ENERGY], structure.energyCapacity - structure.energy))
     } else {
-      creep.travelTo(structure)
+      const opts = {}
+      if (structure.structureType === STRUCTURE_TOWER) {
+        opts.ignoreCore = true
+      }
+      creep.travelTo(structure, opts)
     }
   }
 }


### PR DESCRIPTION
* Force factotum to sit in the “home” position when accessing core structures.
* Move suicide booth to the left of the primary spawn instead of above it. This stops newly spawned creeps from blocking it.
* Increase the cost of walking in the “hallways” around the core structures. This pushes creeps to interact with storage from above, and to step around core structures except where needed.
* Add `ignoreCore` option to `travelTo` to remove the above penalties, then applied that option to the factotum and any fillers that are loading towers.