### PR TITLE
Fix miners using inactive links

### DIFF
--- a/src/extends/roomposition.js
+++ b/src/extends/roomposition.js
@@ -106,6 +106,23 @@ RoomPosition.prototype.getLink = function () {
   return this.__link
 }
 
+RoomPosition.prototype.getActiveLink = function () {
+    const link = this.getLink()
+    if (!link) {
+        return false
+    }
+
+    if (this.__linkActive) {
+        return link
+    }
+
+    if (typeof this.__linkActive === 'undefined') {
+        this.__linkActive = link.isActive()
+    }
+
+    return (this.__linkActive) ? link : false
+}
+
 RoomPosition.prototype.getMostOpenNeighbor = function (isBuildable = false, includeStructures = true) {
   const steppable = this.getSteppableAdjacent()
   let pos

--- a/src/extends/source.js
+++ b/src/extends/source.js
@@ -14,3 +14,7 @@ Source.prototype.getLink = function () {
   }
   return this.__link
 }
+
+Source.prototype.getActiveLink = function () {
+    return this.pos.getActiveLink()
+}

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -88,6 +88,7 @@ class CityMine extends kernel.process {
     // Identify where the miner should sit and any container should be built
     const minerPos = source.getMiningPosition()
     const link = source.getLink()
+    link = (link.isActive()) ? link : false
 
     // Look for a container
     const containers = _.filter(minerPos.lookFor(LOOK_STRUCTURES), (a) => a.structureType === STRUCTURE_CONTAINER)

--- a/src/programs/city/mine.js
+++ b/src/programs/city/mine.js
@@ -88,7 +88,7 @@ class CityMine extends kernel.process {
     // Identify where the miner should sit and any container should be built
     const minerPos = source.getMiningPosition()
     const link = source.getLink()
-    link = (link.isActive()) ? link : false
+    link = source.getActiveLink()
 
     // Look for a container
     const containers = _.filter(minerPos.lookFor(LOOK_STRUCTURES), (a) => a.structureType === STRUCTURE_CONTAINER)


### PR DESCRIPTION
When a link is inactive (for example because of insufficient RCL) miners didn't build containers and dropped their energy to the ground where they weren't picked up. They now check for link activity before using it.