### PR TITLE
Fix npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   ],
   "homepage": "http://quorum.tedivm.com",
   "license": "MIT",
+  "files": [
+    "dist/*"
+  ],
   "main": "dist/main.js",
   "repository": "ScreepsQuorum/screeps-quorum",
   "scripts": {


### PR DESCRIPTION
Currently the `dist/` directory is excluded in the .gitignore which results in
the bot not being installable. With this change only the `dist` directory,
LICENSE, package.json and README.md will be included in the npm build which
also means a smaller overall package size.