### PR TITLE
Catch and condense heap errors

### DIFF
--- a/src/qos/kernel.js
+++ b/src/qos/kernel.js
@@ -120,10 +120,16 @@ class QosKernel {
         }
         this.performance.addProgramStats(performanceName, Game.cpu.getUsed() - startCpu)
       } catch (err) {
-        let message = 'program error occurred\n'
-        message += `process ${runningProcess.pid}: ${runningProcess.name}\n`
-        message += !!err && !!err.stack ? err.stack : err.toString()
-        Logger.log(message, LOG_ERROR)
+        const errorText = !!err && !!err.stack ? err.stack : err.toString()
+        if (errorText.startsWith('RangeError: Array buffer allocation failed')) {
+          let message = 'RangeError: Array buffer allocation failed'
+          Logger.log(message, LOG_ERROR, 'ivm')
+        } else {
+          let message = 'program error occurred\n'
+          message += `process ${runningProcess.pid}: ${runningProcess.name}\n`
+          message += errorText
+          Logger.log(message, LOG_ERROR)
+        }
       }
       Logger.defaultLogGroup = 'default'
     }


### PR DESCRIPTION
This does two things-

1. Reduces the actual text from heap errors into a standard message.

2. Gives these messages their own group, `ivm`.

The combination of these two things will both reduce the number and the annoyance of these messages.