### PR TITLE
Basic Stats module

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
       "Empire",
       "kernel",
       "Logger",
+      "QosStats",
       "PathCache",
       "AGGRESSION_SCORES",
       "AGGRESSION_ATTACK",

--- a/src/extends/room/construction.js
+++ b/src/extends/room/construction.js
@@ -509,7 +509,7 @@ class DefenseMap extends RoomLayout {
     // plan walls around each exit, hugging them directly.
     // This *has* to be done after edge calculatons
     const exits = this.roomname === 'sim' ? ['1', '3', '5', '7']
-                                          : Object.keys(Game.map.describeExits(this.roomname))
+      : Object.keys(Game.map.describeExits(this.roomname))
     for (let exit of exits) {
       exit = parseInt(exit)
       const pieces = this._getExitPieces(exit)

--- a/src/main.js
+++ b/src/main.js
@@ -14,6 +14,10 @@ require('constants')
 const QosLogger = require('qos_logger')
 global.Logger = new QosLogger()
 
+/* Enable Stats */
+const QosStats = require('qos_stats')
+global.QosStats = new QosStats()
+
 /* Add "sos library" - https://github.com/ScreepsOS/sos-library */
 global.SOS_LIB_PREFIX = 'thirdparty_'
 global.sos_lib = require('thirdparty_sos_lib')

--- a/src/qos/kernel.js
+++ b/src/qos/kernel.js
@@ -229,6 +229,17 @@ class QosKernel {
     const processCount = this.scheduler.getProcessCount()
     const completedCount = this.scheduler.memory.processes.completed.length
 
+    QosStats.gameStat('processes_completed', completedCount)
+    QosStats.gameStat('processes_count', processCount)
+    QosStats.gameStat('tick_limit', Game.cpu.tickLimit)
+    QosStats.gameStat('cpu_used', Game.cpu.getUsed())
+    QosStats.gameStat('bucket', Game.cpu.bucket)
+    if (IVM) {
+      const heap = Game.cpu.getHeapStatistics()
+      QosStats.gameStat('total_heap_size', heap.total_heap_size)
+      QosStats.gameStat('heap_size_limit', heap.heap_size_limit)
+    }
+
     if (Memory.userConfig && Memory.userConfig.terseConsole) {
       let message = ''
       message += `PS: ${_.padLeft(`${completedCount}/${processCount}`, 7)}`

--- a/src/qos/stats.js
+++ b/src/qos/stats.js
@@ -1,0 +1,13 @@
+'use strict'
+
+class QosStats {
+  constructor () {
+    Memory.stats = Memory.stats || {}
+    Memory.stats.game = Memory.stats.game || {}
+  }
+  gameStat (name, value) {
+    Memory.stats.game[name] = value
+  }
+}
+
+module.exports = QosStats


### PR DESCRIPTION
Basic status module for use with screepspl.us.  Once the agent is deploy the
stats are successfully collected and pushed to the ScreepsPlus graphite.

Currently only supports very basic room stats.