### PR TITLE
Expand tweaks and logging

### DIFF
--- a/src/programs/empire/expand.js
+++ b/src/programs/empire/expand.js
@@ -10,7 +10,7 @@
  * - Figures out which rooms in the empire are most able to help and utilizes them.
  */
 
-const VERSION = 1.1
+const VERSION = 1.2
 
 class EmpireExpand extends kernel.process {
   constructor (...args) {
@@ -28,11 +28,15 @@ class EmpireExpand extends kernel.process {
   main () {
     Logger.log(`expansion: ${this.getDescriptor()}`)
 
-    // Resart program (if it hasn't gone to far) so that the best candidate gets picked.
+    // Restart program (if it hasn't gone to far) so that the best candidate gets picked.
     if (!this.data.version || this.data.version !== VERSION) {
       if (this.data.colony || this.data.candidates || this.data.candidateList) {
         if (!Game.rooms[this.data.colony] || !Game.rooms[this.data.colony].controller.my) {
           this.suicide()
+        } else {
+          // Reset some variables but don't restart the program.
+          this.data.claimedAt = Game.time
+          this.data.hascleared = false
         }
       }
     }
@@ -103,6 +107,7 @@ class EmpireExpand extends kernel.process {
     // Destroy all neutral and hostile structures immediately
     if (!this.data.recover && !this.data.hascleared) {
       const structures = this.colony.find(FIND_STRUCTURES)
+      this.data.hascleared = true
       for (let structure of structures) {
         if (structure.structureType === STRUCTURE_CONTROLLER) {
           continue
@@ -110,13 +115,14 @@ class EmpireExpand extends kernel.process {
         if (structure.my) {
           continue
         }
-        structure.destroy()
+        this.data.hascleared = false
+        Logger.log(`Attempting to destroy structure ${structure.structureType}: ${structure.destroy()}`)
       }
       const sites = this.colony.find(FIND_HOSTILE_CONSTRUCTION_SITES)
       for (let site of sites) {
+        this.data.hascleared = false
         site.remove()
       }
-      this.data.hascleared = true
       return
     }
 


### PR DESCRIPTION
This is an attempt to get more information from the console about why the expand program is failing.

* Changes how `hascleared` is calculated so it only gets flagged if itactually works.
* Log attempt to destroy structures to see why it fails.
* Tweak the version change code so we don’t have to wait for the program to die for these changes to take affect.