### PR TITLE
Possible expansion fix

### DIFF
--- a/src/programs/empire/expand.js
+++ b/src/programs/empire/expand.js
@@ -48,6 +48,7 @@ class EmpireExpand extends kernel.process {
         this.data.colony = candidate
         this.data.attemptedClaim = 0
         this.data.lastClaimAttempt = false
+        delete this.data.deathwatch
       }
       return
     }


### PR DESCRIPTION
deathwatch was set -> expansion failed, deathwatch stayed -> then we have [this](https://github.com/ScreepsQuorum/screeps-quorum/blob/master/src/programs/empire/expand.js#L358) -> no builders / upgraders are queued

I hope that this makes expansion work again, it's hard to test because the issue is on the official server.