### PR TITLE
Failing to fortify with ramparts

### DIFF
--- a/src/programs/city/construct.js
+++ b/src/programs/city/construct.js
@@ -65,7 +65,7 @@ class CityConstruct extends kernel.process {
 
     const sites = this.room.find(FIND_MY_CONSTRUCTION_SITES, {
       filter: function (structure) {
-        return !ignoreConstructionSites.includes(structure)
+        return !ignoreConstructionSites.includes(structure.structureType)
       }
     })
 

--- a/src/programs/city/fortify.js
+++ b/src/programs/city/fortify.js
@@ -167,17 +167,15 @@ class CityFortify extends kernel.process {
       target = potentialTargets.length > 0 ? Game.getObjectById(potentialTargets[0]) : false
     }
     if (missing.length > 0 && (!target || target.hits > DECAY_LIMIT)) {
-      // Add structure
-      let type = STRUCTURE_RAMPART
-      if (this.defenses.getStructureAt(missing[0].x, missing[0].y) === WALL_GATEWAY) {
-        type = STRUCTURE_WALL
-      }
-
       // Don't let misplaced fortifications block fortifying
       let i = 0
-      while (i < missing.length && this.room.createConstructionSite(missing[i], type) !== 0) {
-        i++
+      while( i < missing.length && 
+            this.room.createConstructionSite(missing[i], this.defenses.getStructureAt(missing[i].x, missing[i].y) === WALL_GATEWAY ? STRUCTURE_WALL : STRUCTURE_RAMPART) != 0
+           ) {
+          i++
       }
+      return false
+    }
       return false
     }
     if (!target) {

--- a/src/programs/city/fortify.js
+++ b/src/programs/city/fortify.js
@@ -175,7 +175,7 @@ class CityFortify extends kernel.process {
       
       //Don't let misplaced fortifications block fortifying
       let i = 0
-      while(this.room.createConstructionSite(missing[i], type) != 0 && i < missing.length) {
+      while(i < missing.length && this.room.createConstructionSite(missing[i], type) != 0) {
           i++
       }
       return false

--- a/src/programs/city/fortify.js
+++ b/src/programs/city/fortify.js
@@ -156,6 +156,7 @@ class CityFortify extends kernel.process {
       }
     }
 
+
     let target
     if (decaying.length > 0) {
       decaying.sort((a, b) => a.hits - b.hits)
@@ -166,16 +167,14 @@ class CityFortify extends kernel.process {
       })
       target = potentialTargets.length > 0 ? Game.getObjectById(potentialTargets[0]) : false
     }
+    
     if (missing.length > 0 && (!target || target.hits > DECAY_LIMIT)) {
-      // Don't let misplaced fortifications block fortifying
+
+      //Don't let misplaced fortifications block fortifying
       let i = 0
-      while( i < missing.length && 
-            this.room.createConstructionSite(missing[i], this.defenses.getStructureAt(missing[i].x, missing[i].y) === WALL_GATEWAY ? STRUCTURE_WALL : STRUCTURE_RAMPART) != 0
-           ) {
+      while( i < missing.length && this.room.createConstructionSite(missing[i], this.defenses.getStructureAt(missing[i].x, missing[i].y) === WALL_GATEWAY ? STRUCTURE_WALL : STRUCTURE_RAMPART) != 0) {
           i++
       }
-      return false
-    }
       return false
     }
     if (!target) {

--- a/src/programs/city/fortify.js
+++ b/src/programs/city/fortify.js
@@ -172,7 +172,7 @@ class CityFortify extends kernel.process {
       if (this.defenses.getStructureAt(missing[0].x, missing[0].y) === WALL_GATEWAY) {
         type = STRUCTURE_WALL
       }
-      this.room.createConstructionSite(missing[0], type)
+      
       //Don't let misplaced fortifications block fortifying
       let i = 0
       while(this.room.createConstructionSite(missing[i], type) != 0 && i < missing.length) {

--- a/src/programs/city/fortify.js
+++ b/src/programs/city/fortify.js
@@ -173,6 +173,11 @@ class CityFortify extends kernel.process {
         type = STRUCTURE_WALL
       }
       this.room.createConstructionSite(missing[0], type)
+      //Don't let misplaced fortifications block fortifying
+      let i = 0
+      while(this.room.createConstructionSite(missing[i], type) != 0 && i < missing.length) {
+          i++
+      }
       return false
     }
     if (!target) {

--- a/src/programs/city/fortify.js
+++ b/src/programs/city/fortify.js
@@ -172,11 +172,11 @@ class CityFortify extends kernel.process {
       if (this.defenses.getStructureAt(missing[0].x, missing[0].y) === WALL_GATEWAY) {
         type = STRUCTURE_WALL
       }
-      
-      //Don't let misplaced fortifications block fortifying
+
+      // Don't let misplaced fortifications block fortifying
       let i = 0
-      while(i < missing.length && this.room.createConstructionSite(missing[i], type) != 0) {
-          i++
+      while (i < missing.length && this.room.createConstructionSite(missing[i], type) !== 0) {
+        i++
       }
       return false
     }


### PR DESCRIPTION
I ran into a couple issues building ramparts in one of my rooms. 

1.  Fixes #414 It would still spawn normal builders because the `!ignoreConstructionSites.includes(structure)` wasn't doing the proper comparison. 

2. Fixes #254, which was caused by trying to build a rampart on a natural wall when the room is crowded.