### PR TITLE
Fixes stuck construct process in Sim and Novice Areas

### DIFF
--- a/src/programs/city/construct.js
+++ b/src/programs/city/construct.js
@@ -52,6 +52,10 @@ class CityConstruct extends kernel.process {
           continue
         }
 
+        if (structure.hits == undefined) { //Skips things that can't be removed, I.E. Novice area walls, SK lair (can break sim)
+          continue
+        }
+
         this.data.hascleared = false
         Logger.log(`Attempting to destroy structure ${structure.structureType}: ${structure.destroy()}`)
       }

--- a/src/programs/city/construct.js
+++ b/src/programs/city/construct.js
@@ -52,7 +52,7 @@ class CityConstruct extends kernel.process {
           continue
         }
 
-        if (structure.hits === undefined) { //Skips things that can't be removed, I.E. Novice area walls, SK lair (can break sim)
+        if (structure.hits === undefined) { // Skips things that can't be removed, I.E. Novice area walls, SK lair (can break sim)
           continue
         }
 

--- a/src/programs/city/construct.js
+++ b/src/programs/city/construct.js
@@ -38,7 +38,7 @@ class CityConstruct extends kernel.process {
       this.data.hascleared = true
       for (const structure of structures) {
         // Skips things that can't be removed, I.E. Controllers, Novice area walls, SK lair (can break sim)
-        if (structure.hits === undefined) { 
+        if (structure.hits === undefined) {
           continue
         }
         if (structure.my) {

--- a/src/programs/city/construct.js
+++ b/src/programs/city/construct.js
@@ -37,7 +37,7 @@ class CityConstruct extends kernel.process {
       const miningPositions = this.room.find(FIND_SOURCES).map(s => s.getMiningPosition())
       this.data.hascleared = true
       for (const structure of structures) {
-        if (structure.structureType === STRUCTURE_CONTROLLER) {
+        if (structure.hits === undefined) { // Skips things that can't be removed, I.E. Controllers, Novice area walls, SK lair (can break sim)
           continue
         }
         if (structure.my) {
@@ -52,9 +52,6 @@ class CityConstruct extends kernel.process {
           continue
         }
 
-        if (structure.hits === undefined) { // Skips things that can't be removed, I.E. Novice area walls, SK lair (can break sim)
-          continue
-        }
 
         this.data.hascleared = false
         Logger.log(`Attempting to destroy structure ${structure.structureType}: ${structure.destroy()}`)

--- a/src/programs/city/construct.js
+++ b/src/programs/city/construct.js
@@ -37,7 +37,8 @@ class CityConstruct extends kernel.process {
       const miningPositions = this.room.find(FIND_SOURCES).map(s => s.getMiningPosition())
       this.data.hascleared = true
       for (const structure of structures) {
-        if (structure.hits === undefined) { // Skips things that can't be removed, I.E. Controllers, Novice area walls, SK lair (can break sim)
+        // Skips things that can't be removed, I.E. Controllers, Novice area walls, SK lair (can break sim)
+        if (structure.hits === undefined) { 
           continue
         }
         if (structure.my) {

--- a/src/programs/city/construct.js
+++ b/src/programs/city/construct.js
@@ -52,7 +52,7 @@ class CityConstruct extends kernel.process {
           continue
         }
 
-        if (structure.hits == undefined) { //Skips things that can't be removed, I.E. Novice area walls, SK lair (can break sim)
+        if (structure.hits === undefined) { //Skips things that can't be removed, I.E. Novice area walls, SK lair (can break sim)
           continue
         }
 

--- a/src/programs/city/construct.js
+++ b/src/programs/city/construct.js
@@ -53,7 +53,6 @@ class CityConstruct extends kernel.process {
           continue
         }
 
-
         this.data.hascleared = false
         Logger.log(`Attempting to destroy structure ${structure.structureType}: ${structure.destroy()}`)
       }


### PR DESCRIPTION
Construct process would get stuck if it couldn't remove certain structures, like novice walls or a Keeper Source. This caused poor performance in the sim room and prevents building in edge novice rooms.