### PR TITLE
Replaces `this.storage.storage` which is undefined

### DIFF
--- a/src/extends/room/economy.js
+++ b/src/extends/room/economy.js
@@ -92,7 +92,7 @@ Room.prototype.getEconomyLevel = function () {
   }
 
   // Need to ditch energy as we have way too much in storage
-  if (_.sum(this.storage.storage) > this.storage.storeCapacity * 0.9) {
+  if (this.storage.store.getUsedCapacity() > this.storage.storeCapacity * 0.9) {
     return ECONOMY_BURSTING
   }
 


### PR DESCRIPTION
`this.storage.storage` is undefined and will prevent the economy from reporting that it is bursting. 