### PR TITLE
Type differences causes check to always be false

### DIFF
--- a/src/programs/city/fortify.js
+++ b/src/programs/city/fortify.js
@@ -132,8 +132,8 @@ class CityFortify extends kernel.process {
         continue
       }
       for (const position of structures[type]) {
-        // Don't build structure ramparts unless there's a structure.
-        if (type == RAMPART_PRIMARY_STRUCTURES || type == RAMPART_SECONDARY_STRUCTURES) {
+        // Don't build structure ramparts unless there's a structure. Object keys are strings, so convert them to int for comparison sake
+        if (Number(type) === RAMPART_PRIMARY_STRUCTURES || Number(type) === RAMPART_SECONDARY_STRUCTURES) {
           if (position.lookFor(LOOK_STRUCTURES).length <= 0) {
             continue
           }

--- a/src/programs/city/fortify.js
+++ b/src/programs/city/fortify.js
@@ -133,7 +133,7 @@ class CityFortify extends kernel.process {
       }
       for (const position of structures[type]) {
         // Don't build structure ramparts unless there's a structure.
-        if (type === RAMPART_PRIMARY_STRUCTURES || type === RAMPART_SECONDARY_STRUCTURES) {
+        if (type == RAMPART_PRIMARY_STRUCTURES || type == RAMPART_SECONDARY_STRUCTURES) {
           if (position.lookFor(LOOK_STRUCTURES).length <= 0) {
             continue
           }


### PR DESCRIPTION
Object Keys are returned as `string`s, while the global is stored as a `number`. There were a couple different ways to fix this, this way changed fewer lines of code.

This prevents an issue where locations without structures were still being fortified. 

![image](https://user-images.githubusercontent.com/13244305/104107403-82951800-5281-11eb-81b3-cb674de30a2c.png)
